### PR TITLE
KBC-2910 fix build for tags

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     tags:
-      - '*'
+      - '**'
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
Tohle jsme řešili včera odpoledne s tím, jak se nepropisují tagy. Bylo to tím, že tagy jsou prozatím zařazené v podsložce podle projektu a `*` to nematchne a musí tam být `**`. 