### PR TITLE
Add docker and monorepo-builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .idea
+/composer.lock
+/vendor/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,71 @@
+# syntax=docker/dockerfile:1.3
+
+ARG PHP_VERSION=8.1
+
+FROM php:${PHP_VERSION}-cli-buster AS base
+
+ARG COMPOSER_FLAGS="--prefer-dist --no-interaction"
+ARG DEBIAN_FRONTEND=noninteractive
+ENV COMPOSER_ALLOW_SUPERUSER 1
+ENV COMPOSER_PROCESS_TIMEOUT 3600
+
+ARG SQLSRV_VERSION=5.10.1
+ARG SNOWFLAKE_ODBC_VERSION=2.25.6
+ARG SNOWFLAKE_GPG_KEY=630D9F3CAB551AF3
+
+WORKDIR /code/
+
+COPY docker/php/php.ini /usr/local/etc/php/php.ini
+COPY docker/php/xdebug.ini /usr/local/etc/php/conf.d/
+
+RUN apt-get update -q \
+    && apt-get install gnupg -y --no-install-recommends \
+    && curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
+    && curl https://packages.microsoft.com/config/debian/10/prod.list > /etc/apt/sources.list.d/mssql-release.list \
+    && apt-get update -q \
+    && ACCEPT_EULA=Y apt-get install -y --no-install-recommends\
+        git \
+        locales \
+        unzip \
+        unixodbc \
+        unixodbc-dev \
+        libpq-dev \
+        gpg \
+        debsig-verify \
+        dirmngr \
+        gpg-agent \
+        libonig-dev \
+        libxml2-dev \
+	&& rm -r /var/lib/apt/lists/* \
+	&& sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen \
+	&& locale-gen \
+    && docker-php-ext-configure intl \
+    && docker-php-ext-install intl
+
+ENV LANGUAGE=en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
+
+# Snowflake ODBC
+# https://github.com/docker-library/php/issues/103#issuecomment-353674490
+RUN set -ex; \
+    docker-php-source extract; \
+    { \
+        echo '# https://github.com/docker-library/php/issues/103#issuecomment-353674490'; \
+        echo 'AC_DEFUN([PHP_ALWAYS_SHARED],[])dnl'; \
+        echo; \
+        cat /usr/src/php/ext/odbc/config.m4; \
+    } > temp.m4; \
+    mv temp.m4 /usr/src/php/ext/odbc/config.m4; \
+    docker-php-ext-configure odbc --with-unixODBC=shared,/usr; \
+    docker-php-ext-install odbc; \
+    docker-php-source delete
+
+
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin/ --filename=composer
+
+RUN pecl install xdebug-3.1.6 \
+ && docker-php-ext-enable xdebug
+
+FROM base AS dev
+WORKDIR /code

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,52 @@
+{
+    "name": "keboola/storage-backend",
+    "authors": [
+        {
+            "name": "Keboola",
+            "email": "devel@keboola.com"
+        }
+    ],
+    "require": {
+        "doctrine/dbal": "^3.3",
+        "ext-json": "*",
+        "ext-odbc": "*",
+        "ext-pdo": "*",
+        "google/cloud-bigquery": "^1.23",
+        "keboola/common-exceptions": "^1",
+        "keboola/php-utils": "^4.1",
+        "keboola/retry": "^0.5.0",
+        "php": "^7.4|^8"
+    },
+    "require-dev": {
+        "keboola/coding-standard": "^13.0",
+        "php-parallel-lint/php-parallel-lint": "^1",
+        "phpstan/phpdoc-parser": "1.5.1",
+        "phpstan/phpstan": "^1",
+        "phpstan/phpstan-phpunit": "^1",
+        "phpunit/phpunit": "^9",
+        "squizlabs/php_codesniffer": "^3",
+        "symplify/monorepo-builder": "11.1.30.72"
+    },
+    "autoload": {
+        "psr-4": {
+            "Keboola\\StorageBackend\\": "src/",
+            "Keboola\\Datatype\\": "packages/php-datatypes/src/",
+            "Keboola\\TableBackendUtils\\": "packages/php-table-backend-utils/src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Keboola\\DatatypeTest\\": "packages/php-datatypes/tests/",
+            "Tests\\Keboola\\TableBackendUtils\\": "packages/php-table-backend-utils/tests"
+        }
+    },
+    "replace": {
+        "keboola/php-datatypes": "self.version",
+        "keboola/table-backend-utils": "self.version"
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.4"
+
+services:
+  dev:
+    profiles: [ ci, dev ]
+    build:
+      context: .
+      target: dev
+    working_dir: /code
+    command: [ /bin/bash ]
+    volumes:
+      - .:/code
+

--- a/docker/php/php.ini
+++ b/docker/php/php.ini
@@ -1,0 +1,19 @@
+; Recommended production values
+display_errors = Off
+display_startup_errors = Off
+error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
+html_errors = Off
+log_errors = On
+max_input_time = 60
+output_buffering = 4096
+register_argc_argv = Off
+request_order = "GP"
+session.gc_divisor = 1000
+session.sid_bits_per_character = 5
+short_open_tag = Off
+track_errors = Off
+variables_order = "GPCS"
+
+; Custom
+date.timezone = UTC
+memory_limit = -1

--- a/docker/php/xdebug.ini
+++ b/docker/php/xdebug.ini
@@ -1,0 +1,6 @@
+[xdebug]
+xdebug.mode=develop
+xdebug.start_with_request=yes
+xdebug.discover_client_host=0
+xdebug.client_host=host.docker.internal
+xdebug.max_nesting_level = 250

--- a/monorepo-builder.php
+++ b/monorepo-builder.php
@@ -19,11 +19,9 @@ return static function (MBConfig $mbConfig): void {
     $mbConfig->packageDirectories([__DIR__ . '/packages']);
     // register custom most recent tag resolver
     $servicesConfigurator = $mbConfig->services();
-    $servicesConfigurator->defaults()
-        ->public()
+    $servicesConfigurator
+        ->set(TagResolverInterface::class, MostRecentTagWithoutRepositoryPrefixResolver::class)
         ->autowire();
-    $servicesConfigurator->set(TagResolverInterface::class, MostRecentTagWithoutRepositoryPrefixResolver::class);
-
 
     $mbConfig->workers([
         UpdateReplaceReleaseWorker::class,

--- a/monorepo-builder.php
+++ b/monorepo-builder.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use Keboola\StorageBackend\MostRecentTagWithoutRepositoryPrefixResolver;
+use Symplify\MonorepoBuilder\Config\MBConfig;
+use Symplify\MonorepoBuilder\Contract\Git\TagResolverInterface;
+use Symplify\MonorepoBuilder\Release\Process\ProcessRunner;
+use Symplify\MonorepoBuilder\Release\ReleaseWorker\AddTagToChangelogReleaseWorker;
+use Symplify\MonorepoBuilder\Release\ReleaseWorker\PushNextDevReleaseWorker;
+use Symplify\MonorepoBuilder\Release\ReleaseWorker\PushTagReleaseWorker;
+use Symplify\MonorepoBuilder\Release\ReleaseWorker\SetCurrentMutualDependenciesReleaseWorker;
+use Symplify\MonorepoBuilder\Release\ReleaseWorker\SetNextMutualDependenciesReleaseWorker;
+use Symplify\MonorepoBuilder\Release\ReleaseWorker\TagVersionReleaseWorker;
+use Symplify\MonorepoBuilder\Release\ReleaseWorker\UpdateBranchAliasReleaseWorker;
+use Symplify\MonorepoBuilder\Release\ReleaseWorker\UpdateReplaceReleaseWorker;
+
+return static function (MBConfig $mbConfig): void {
+    $mbConfig->packageDirectories([__DIR__ . '/packages']);
+    // register custom most recent tag resolver
+    $servicesConfigurator = $mbConfig->services();
+    $servicesConfigurator->defaults()
+        ->public()
+        ->autowire();
+    $servicesConfigurator->set(TagResolverInterface::class, MostRecentTagWithoutRepositoryPrefixResolver::class);
+
+
+    $mbConfig->workers([
+        UpdateReplaceReleaseWorker::class,
+        SetCurrentMutualDependenciesReleaseWorker::class,
+        AddTagToChangelogReleaseWorker::class,
+        TagVersionReleaseWorker::class,
+        PushTagReleaseWorker::class,
+        SetNextMutualDependenciesReleaseWorker::class,
+        UpdateBranchAliasReleaseWorker::class,
+        PushNextDevReleaseWorker::class,
+    ]);
+};

--- a/monorepo-builder.php
+++ b/monorepo-builder.php
@@ -30,9 +30,9 @@ return static function (MBConfig $mbConfig): void {
         SetCurrentMutualDependenciesReleaseWorker::class,
         AddTagToChangelogReleaseWorker::class,
         TagVersionReleaseWorker::class,
-        PushTagReleaseWorker::class,
+//        PushTagReleaseWorker::class,
         SetNextMutualDependenciesReleaseWorker::class,
         UpdateBranchAliasReleaseWorker::class,
-        PushNextDevReleaseWorker::class,
+//        PushNextDevReleaseWorker::class,
     ]);
 };

--- a/packages/php-table-backend-utils/composer.json
+++ b/packages/php-table-backend-utils/composer.json
@@ -15,7 +15,7 @@
         "keboola/retry": "^0.5.0"
     },
     "require-dev": {
-        "keboola/coding-standard": "^13",
+        "keboola/coding-standard": "^13.0",
         "php-parallel-lint/php-parallel-lint": "^1",
         "phpstan/phpstan": "^1",
         "phpstan/phpstan-phpunit": "^1",

--- a/packages/php-table-backend-utils/phpstan-baseline.neon
+++ b/packages/php-table-backend-utils/phpstan-baseline.neon
@@ -36,11 +36,26 @@ parameters:
 			path: src/Connection/ConnectionRetryWrapper.php
 
 		-
-			message: "#^Parameter \\#1 \\$params of static method Doctrine\\\\DBAL\\\\DriverManager\\:\\:getConnection\\(\\) expects array\\{charset\\?\\: string, dbname\\?\\: string, default_dbname\\?\\: string, driver\\?\\: 'ibm_db2'\\|'mysqli'\\|'oci8'\\|'pdo_mysql'\\|'pdo_oci'\\|'pdo_pgsql'\\|'pdo_sqlite'\\|'pdo_sqlsrv'\\|'sqlite3'\\|'sqlsrv', driverClass\\?\\: class\\-string\\<Doctrine\\\\DBAL\\\\Driver\\>, driverOptions\\?\\: array, host\\?\\: string, keepSlave\\?\\: bool, \\.\\.\\.\\}, array\\{port\\?\\: string, warehouse\\?\\: string, database\\?\\: string, schema\\?\\: string, tracing\\?\\: int, loginTimeout\\?\\: int, networkTimeout\\?\\: int, queryTimeout\\?\\: int, \\.\\.\\.\\} given\\.$#"
+			message: "#^Parameter \\#1 \\$params \\(array\\{host\\: string, user\\: string, password\\: string, skipCertCheck\\: bool\\}\\) of method Keboola\\\\TableBackendUtils\\\\Connection\\\\Exasol\\\\ExasolDriver\\:\\:connect\\(\\) should be compatible with parameter \\$params \\(array\\{charset\\?\\: string, dbname\\?\\: string, defaultTableOptions\\?\\: array\\<string, mixed\\>, default_dbname\\?\\: string, driver\\?\\: 'ibm_db2'\\|'mysqli'\\|'oci8'\\|'pdo_mysql'\\|'pdo_oci'\\|'pdo_pgsql'\\|'pdo_sqlite'\\|'pdo_sqlsrv'\\|'pgsql'\\|'sqlite3'\\|'sqlsrv', driverClass\\?\\: class\\-string\\<Doctrine\\\\DBAL\\\\Driver\\>, driverOptions\\?\\: array, host\\?\\: string, \\.\\.\\.\\}\\) of method Doctrine\\\\DBAL\\\\Driver\\:\\:connect\\(\\)$#"
+			count: 1
+			path: src/Connection/Exasol/ExasolDriver.php
+
+		-
+			message: "#^Parameter \\#1 \\$params of static method Doctrine\\\\DBAL\\\\DriverManager\\:\\:getConnection\\(\\) expects array\\{charset\\?\\: string, dbname\\?\\: string, defaultTableOptions\\?\\: array\\<string, mixed\\>, default_dbname\\?\\: string, driver\\?\\: 'ibm_db2'\\|'mysqli'\\|'oci8'\\|'pdo_mysql'\\|'pdo_oci'\\|'pdo_pgsql'\\|'pdo_sqlite'\\|'pdo_sqlsrv'\\|'pgsql'\\|'sqlite3'\\|'sqlsrv', driverClass\\?\\: class\\-string\\<Doctrine\\\\DBAL\\\\Driver\\>, driverOptions\\?\\: array, host\\?\\: string, \\.\\.\\.\\}, array\\{port\\?\\: string, warehouse\\?\\: string, database\\?\\: string, schema\\?\\: string, tracing\\?\\: int, loginTimeout\\?\\: int, networkTimeout\\?\\: int, queryTimeout\\?\\: int, \\.\\.\\.\\} given\\.$#"
 			count: 1
 			path: src/Connection/Snowflake/SnowflakeConnectionFactory.php
 
 		-
-			message: "#^Parameter \\#1 \\$params of static method Doctrine\\\\DBAL\\\\DriverManager\\:\\:getConnection\\(\\) expects array\\{charset\\?\\: string, dbname\\?\\: string, default_dbname\\?\\: string, driver\\?\\: 'ibm_db2'\\|'mysqli'\\|'oci8'\\|'pdo_mysql'\\|'pdo_oci'\\|'pdo_pgsql'\\|'pdo_sqlite'\\|'pdo_sqlsrv'\\|'sqlite3'\\|'sqlsrv', driverClass\\?\\: class\\-string\\<Doctrine\\\\DBAL\\\\Driver\\>, driverOptions\\?\\: array, host\\?\\: string, keepSlave\\?\\: bool, \\.\\.\\.\\}, array\\{host\\: string, user\\: string, password\\: string, port\\: int, dbname\\: string\\|null, driverClass\\: 'Keboola\\\\\\\\TableBackendUtils\\\\\\\\Connection\\\\\\\\Teradata\\\\\\\\TeradataDriver'\\} given\\.$#"
+			message: "#^Parameter \\#1 \\$params \\(array\\{host\\: string, user\\: string, password\\: string, port\\?\\: string, warehouse\\?\\: string, database\\?\\: string, schema\\?\\: string, tracing\\?\\: int, \\.\\.\\.\\}\\) of method Keboola\\\\TableBackendUtils\\\\Connection\\\\Snowflake\\\\SnowflakeDriver\\:\\:connect\\(\\) should be compatible with parameter \\$params \\(array\\{charset\\?\\: string, dbname\\?\\: string, defaultTableOptions\\?\\: array\\<string, mixed\\>, default_dbname\\?\\: string, driver\\?\\: 'ibm_db2'\\|'mysqli'\\|'oci8'\\|'pdo_mysql'\\|'pdo_oci'\\|'pdo_pgsql'\\|'pdo_sqlite'\\|'pdo_sqlsrv'\\|'pgsql'\\|'sqlite3'\\|'sqlsrv', driverClass\\?\\: class\\-string\\<Doctrine\\\\DBAL\\\\Driver\\>, driverOptions\\?\\: array, host\\?\\: string, \\.\\.\\.\\}\\) of method Doctrine\\\\DBAL\\\\Driver\\:\\:connect\\(\\)$#"
+			count: 1
+			path: src/Connection/Snowflake/SnowflakeDriver.php
+
+		-
+			message: "#^Offset 'persistent' on array\\{charset\\?\\: string, dbname\\?\\: string, defaultTableOptions\\?\\: array\\<string, mixed\\>, default_dbname\\?\\: string, driver\\?\\: 'ibm_db2'\\|'mysqli'\\|'oci8'\\|'pdo_mysql'\\|'pdo_oci'\\|'pdo_pgsql'\\|'pdo_sqlite'\\|'pdo_sqlsrv'\\|'pgsql'\\|'sqlite3'\\|'sqlsrv', driverClass\\?\\: class\\-string\\<Doctrine\\\\DBAL\\\\Driver\\>, driverOptions\\?\\: array, host\\?\\: string, \\.\\.\\.\\} in empty\\(\\) does not exist\\.$#"
+			count: 1
+			path: src/Connection/Synapse/SynapseDriver.php
+
+		-
+			message: "#^Parameter \\#1 \\$params of static method Doctrine\\\\DBAL\\\\DriverManager\\:\\:getConnection\\(\\) expects array\\{charset\\?\\: string, dbname\\?\\: string, defaultTableOptions\\?\\: array\\<string, mixed\\>, default_dbname\\?\\: string, driver\\?\\: 'ibm_db2'\\|'mysqli'\\|'oci8'\\|'pdo_mysql'\\|'pdo_oci'\\|'pdo_pgsql'\\|'pdo_sqlite'\\|'pdo_sqlsrv'\\|'pgsql'\\|'sqlite3'\\|'sqlsrv', driverClass\\?\\: class\\-string\\<Doctrine\\\\DBAL\\\\Driver\\>, driverOptions\\?\\: array, host\\?\\: string, \\.\\.\\.\\}, array\\{host\\: string, user\\: string, password\\: string, port\\: int, dbname\\: string\\|null, driverClass\\: 'Keboola\\\\\\\\TableBackendUtils\\\\\\\\Connection\\\\\\\\Teradata\\\\\\\\TeradataDriver'\\} given\\.$#"
 			count: 1
 			path: src/Connection/Teradata/TeradataConnection.php

--- a/src/MostRecentTagWithoutRepositoryPrefixResolver.php
+++ b/src/MostRecentTagWithoutRepositoryPrefixResolver.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\StorageBackend;
+
+
+use Symplify\MonorepoBuilder\Contract\Git\TagResolverInterface;
+use Symplify\MonorepoBuilder\Release\Process\ProcessRunner;
+
+class MostRecentTagWithoutRepositoryPrefixResolver implements TagResolverInterface
+{
+    /**
+     * @var string[]
+     */
+    private const COMMAND = ['git', 'tag', '-l', '--sort=committerdate'];
+    /**
+     * @var \Symplify\MonorepoBuilder\Release\Process\ProcessRunner
+     */
+    private $processRunner;
+    public function __construct(ProcessRunner $processRunner)
+    {
+        $this->processRunner = $processRunner;
+    }
+    /**
+     * Returns null, when there are no local tags yet
+     */
+    public function resolve(string $gitDirectory) : ?string
+    {
+        $tagList = $this->parseTags($this->processRunner->run(self::COMMAND, $gitDirectory));
+        /** @var string $theMostRecentTag */
+        $theMostRecentTag = (string) \array_pop($tagList);
+        if ($theMostRecentTag === '') {
+            return null;
+        }
+        return $theMostRecentTag;
+    }
+    /**
+     * @return string[]
+     */
+    private function parseTags(string $commandResult) : array
+    {
+        $tags = \trim($commandResult);
+        // Remove all "\r" chars in case the CLI env like the Windows OS.
+        // Otherwise (ConEmu, git bash, mingw cli, e.g.), leave as is.
+        $normalizedTags = \str_replace("\r", '', $tags);
+        $tagsArray = \explode("\n", $normalizedTags);
+
+        // Git history contains tags that belonged to repositories before they were in monorepo.
+        // These tags are prefixed with the repository name (php-datatypes/*, etc.) and we don't want to include them.
+        return array_filter($tagsArray, function ($tag) {
+            return preg_match('/^[0-9]+\.[0-9]+\.[0-9]+$/', $tag);
+        });
+    }
+}


### PR DESCRIPTION
Pridavam
- zakladny docker aby siel nainstalovat composer
- monorepo-builder
- custom tag resolver, vyfiltruje to vsetky tagy ktore maju prefix aby slo vydat novu verziu pomocou monorepo-buildera
- je tam este tmp commit ktory zakomentoval veci ktore zalozia tag a pushnu ho aby sme pri review nahodou nieco nepushli :) 

Ako spravit review:
- vsetky commandy su tu https://github.com/symplify/monorepo-builder
- v podstate nas hlavne zaujma release `docker-compose run --rm dev vendor/bin/monorepo-builder release <tag> --dry-run`
- ide spustit v `--dry-run` mode kde to vypise len co bude robit 
- kedze sa monorepo bude vydavat potom vo verziach pre vsetky libky zaroven tzn. po mergi toho PR zavolam
`docker-compose run --rm dev vendor/bin/monorepo-builder release 7.0.0 --dry-run` verzia `7.0.0` pretoze posledna najvatsia verzia pre vsetky repa ktore su alebo budu v monorepe je `6.0.3` 
- mozem zavolat teda lokalne v dry rune, mal by som dostat vypis toho co sa stane 
![Screenshot 2023-02-07 at 11 13 54](https://user-images.githubusercontent.com/6448364/217216475-e227ba25-e171-4e37-801f-4fb4ee9e6184.png)
- ak som stim v pohode tak zavolam force (skontrolujem ze mam stale zakomentovane riadky 33 a 36 v subore `monorepo-builder.php` v rootu aby som nahodou nieco nepushol na GH
- Lokalne by sa mi mal objavit tag `7.0.0` a v composeru v rootu monorepa by sa mali obe verzie nastavit na `7.0.0`
<img width="412" alt="Screenshot 2023-02-07 at 11 15 51" src="https://user-images.githubusercontent.com/6448364/217216920-33dd048f-fc3b-4b9c-8cee-443f5d6961e8.png">
- libka `php-table-backend-utils` requiruje `php-datatypes` takze v zlozke `packages/php-table-backend-utils` v composer.json sa automaticky nastavi posledna verzia 
<img width="296" alt="Screenshot 2023-02-07 at 11 17 11" src="https://user-images.githubusercontent.com/6448364/217217209-ffadbe79-1c98-4c57-a78e-c10f3c95be29.png">

Tim ze este nemame v GH nastavenu tu release flow tak by som toto asi mergol ak to bude v pohode a pokracoval dalej.


1. zistit preco sa zaroven po spusteni posledneho commandu zobrazi unstaged zmena v `packages/php-table-backend-utils` ` "keboola/php-datatypes": "^7.1",` imho to bude nieco ako to nastavuje tie dev branche ale potrebujem zistit ci to nebude robit bordel na GH
2. pripravim v GH Split fazu https://github.com/symplify/monorepo-builder#6-split-directories-to-git-repositories