### PR TITLE
fix github action warnings

### DIFF
--- a/.github/workflows/build-php-table-backend-utils.yml
+++ b/.github/workflows/build-php-table-backend-utils.yml
@@ -93,7 +93,7 @@ jobs:
           docker-compose run production composer check
       -
         name: Upload docker image
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: image
           path: /tmp/php-table-backend-utils.tar
@@ -112,7 +112,7 @@ jobs:
         uses: actions/checkout@v3
       -
         name: Download artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: image
           path: /tmp

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
         contains(fromJson('["success"]'), needs.build_datatypes.result)
     steps:
       - name: Tests passed
-        run: echo "Tests passed"
+        run: echo "Tests passed" >> $GITHUB_STATE
 
   monorepo_split:
     needs: test_results


### PR DESCRIPTION
Opavujem warningy v actions 
pred 
https://github.com/keboola/storage-backend/actions/runs/4027056747
a po 
https://github.com/keboola/storage-backend/actions/runs/4027181126

php-datatypes tam nemaju ziadne