### PR TITLE
Release and split monorepo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release new version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+jobs:
+  bare_run:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        uses: actions/checkout@v3
+      -
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          coverage: none
+      -
+        run: |
+          git config --global user.email "devel@keboola.com"                           
+          git config --global user.name "Keboola CI"
+          LATEST_TAG=$(git -c 'versionsort.suffix=-' ls-remote --exit-code --refs --sort='version:refname' --tags origin '*.*.*' | cut --fields=2 | sed -E --expression="s/(refs\/tags\/)v/\1/g" | sort | tail --lines=1)
+          git fetch origin $LATEST_TAG:$LATEST_TAG
+          composer install
+          php vendor/bin/monorepo-builder release ${{ inputs.version }}

--- a/monorepo-builder.php
+++ b/monorepo-builder.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Keboola\StorageBackend\MostRecentTagWithoutRepositoryPrefixResolver;
+use Keboola\StorageBackend\AddTagPerPackagesWhenRepoIsReleasedWorker;
 use Symplify\MonorepoBuilder\Config\MBConfig;
 use Symplify\MonorepoBuilder\Contract\Git\TagResolverInterface;
 use Symplify\MonorepoBuilder\Release\Process\ProcessRunner;
@@ -27,11 +28,9 @@ return static function (MBConfig $mbConfig): void {
     $mbConfig->workers([
         UpdateReplaceReleaseWorker::class,
         SetCurrentMutualDependenciesReleaseWorker::class,
-        AddTagToChangelogReleaseWorker::class,
         TagVersionReleaseWorker::class,
+        AddTagPerPackagesWhenRepoIsReleasedWorker::class,
 //        PushTagReleaseWorker::class,
-        SetNextMutualDependenciesReleaseWorker::class,
-        UpdateBranchAliasReleaseWorker::class,
 //        PushNextDevReleaseWorker::class,
     ]);
 };

--- a/monorepo-builder.php
+++ b/monorepo-builder.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use Keboola\StorageBackend\MostRecentTagWithoutRepositoryPrefixResolver;
-use Keboola\StorageBackend\AddTagPerPackagesWhenRepoIsReleasedWorker;
+use Keboola\StorageBackend\AddTagPerPackagesWorker;
 use Symplify\MonorepoBuilder\Config\MBConfig;
 use Symplify\MonorepoBuilder\Contract\Git\TagResolverInterface;
 use Symplify\MonorepoBuilder\Release\Process\ProcessRunner;
@@ -29,7 +29,7 @@ return static function (MBConfig $mbConfig): void {
         UpdateReplaceReleaseWorker::class,
         SetCurrentMutualDependenciesReleaseWorker::class,
         TagVersionReleaseWorker::class,
-        AddTagPerPackagesWhenRepoIsReleasedWorker::class,
+        AddTagPerPackagesWorker::class,
 //        PushTagReleaseWorker::class,
 //        PushNextDevReleaseWorker::class,
     ]);

--- a/monorepo-builder.php
+++ b/monorepo-builder.php
@@ -19,6 +19,9 @@ use Symplify\MonorepoBuilder\Release\ReleaseWorker\UpdateReplaceReleaseWorker;
 return static function (MBConfig $mbConfig): void {
     $mbConfig->packageDirectories([__DIR__ . '/packages']);
     // register custom most recent tag resolver
+
+    $mbConfig->packageDirectoriesExcludes([__DIR__ . '/packages/php-db-import-export/provisioning']);
+
     $servicesConfigurator = $mbConfig->services();
     $mbConfig->defaultBranch('main');
     $servicesConfigurator

--- a/src/AddTagPerPackagesWhenRepoIsReleasedWorker.php
+++ b/src/AddTagPerPackagesWhenRepoIsReleasedWorker.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\StorageBackend;
+
+use PharIo\Version\Version;
+use Symplify\MonorepoBuilder\Release\Contract\ReleaseWorker\ReleaseWorkerInterface;
+use Symplify\MonorepoBuilder\Release\Process\ProcessRunner;
+
+final class AddTagPerPackagesWhenRepoIsReleasedWorker implements ReleaseWorkerInterface
+{
+    /**
+     * @var \Symplify\MonorepoBuilder\Release\Process\ProcessRunner
+     */
+    private $processRunner;
+    public function __construct(ProcessRunner $processRunner)
+    {
+        $this->processRunner = $processRunner;
+    }
+    public function work(Version $version) : void
+    {
+//      I have to go through the packages folder, from composer.json it's not possible, they often have different names than the repository itself, what I need for split script
+        $directories = glob('/code/packages/*' , GLOB_ONLYDIR);
+        $directories = array_map(function ($item) {
+            return str_replace('/code/packages/', '', $item);
+        }, $directories);
+
+        foreach ($directories as $directory) {
+            $this->processRunner->run('git tag ' . $directory . '/' . $version->getOriginalString());
+        }
+    }
+
+    public function getDescription(Version $version): string
+    {
+        return 'From the `/packages` folder, it takes all the packages and creates a tag for them on release.';
+    }
+}

--- a/src/AddTagPerPackagesWorker.php
+++ b/src/AddTagPerPackagesWorker.php
@@ -35,6 +35,6 @@ final class AddTagPerPackagesWorker implements ReleaseWorkerInterface
 
     public function getDescription(Version $version): string
     {
-        return sprintf('Add local tag "%s" for all libraries whit a prefix for each lib. e.g. `php-datatypes/7.0.0`, `php-table-backend-utils/7.0.0` ...', $version->getOriginalString());
+        return sprintf('Add local tag "%s" for all libraries with a prefix for each lib. e.g. `php-datatypes/7.0.0`, `php-table-backend-utils/7.0.0` ...', $version->getOriginalString());
     }
 }

--- a/src/AddTagPerPackagesWorker.php
+++ b/src/AddTagPerPackagesWorker.php
@@ -36,9 +36,9 @@ final class AddTagPerPackagesWorker implements ReleaseWorkerInterface
     {
         $packagesFileInfos = $this->getPackagesFileInfos();
 
-        foreach ($packagesFileInfos as $directory) {
+        foreach ($packagesFileInfos as $packagesFileInfo) {
             // e.g. php-datatypes/7.0.0, php-table-backend-utils/7.0.0 ...
-            $tagName = $this->generatePackageTagName($directory, $version);
+            $tagName = $this->generatePackageTagName($packagesFileInfo, $version);
             $this->processRunner->run('git tag ' . $tagName);
         }
     }
@@ -64,8 +64,8 @@ final class AddTagPerPackagesWorker implements ReleaseWorkerInterface
         });
     }
 
-    private function generatePackageTagName(SmartFileInfo $directory, Version $version): string
+    private function generatePackageTagName(SmartFileInfo $smartFileInfo, Version $version): string
     {
-        return basename($directory->getRelativeDirectoryPath()) . '/' . $version->getOriginalString();
+        return basename($smartFileInfo->getRelativeDirectoryPath()) . '/' . $version->getOriginalString();
     }
 }

--- a/src/AddTagPerPackagesWorker.php
+++ b/src/AddTagPerPackagesWorker.php
@@ -8,7 +8,7 @@ use PharIo\Version\Version;
 use Symplify\MonorepoBuilder\Release\Contract\ReleaseWorker\ReleaseWorkerInterface;
 use Symplify\MonorepoBuilder\Release\Process\ProcessRunner;
 
-final class AddTagPerPackagesWhenRepoIsReleasedWorker implements ReleaseWorkerInterface
+final class AddTagPerPackagesWorker implements ReleaseWorkerInterface
 {
     /**
      * @var \Symplify\MonorepoBuilder\Release\Process\ProcessRunner
@@ -27,12 +27,14 @@ final class AddTagPerPackagesWhenRepoIsReleasedWorker implements ReleaseWorkerIn
         }, $directories);
 
         foreach ($directories as $directory) {
-            $this->processRunner->run('git tag ' . $directory . '/' . $version->getOriginalString());
+            // e.g. php-datatypes/7.0.0, php-table-backend-utils/7.0.0 ...
+            $tagName = $directory . '/' . $version->getOriginalString();
+            $this->processRunner->run('git tag ' . $tagName);
         }
     }
 
     public function getDescription(Version $version): string
     {
-        return 'From the `/packages` folder, it takes all the packages and creates a tag for them on release.';
+        return sprintf('Add local tag "%s" for all libraries whit a prefix for each lib. e.g. `php-datatypes/7.0.0`, `php-table-backend-utils/7.0.0` ...', $version->getOriginalString());
     }
 }


### PR DESCRIPTION
https://keboola.atlassian.net/browse/CT-897
Pridavam finalnu fazu kde je mozne po merge v GH spustit rucny release a repo si vytvori svoje tagy pre kazdy repozitar a split script by sa mal postarat o ostatne.

Navod na review:

1. lokalne si spustim release, mam schvalne zakomentovane pushovanie tagov aby sa nestal omyl v dasom PR to odkomentujem a malo byt o byt potom konecne riesenie.
2. takze spustim command `docker-compose run dev bash` potom bude potreba setupnut globalney git email a meno a pustit `./vendor/bin/monorepo-builder release major`  (na CI je to vo workflow, mal som to pridane v docker file ale vlastne to nieje potreba)
3. Lokalne mi to updatne composer vzajomne naviazanych libiek na novu release verziu podla toho ci je to major, minor alebo patch
<img width="1129" alt="Screenshot 2023-03-05 at 18 39 09" src="https://user-images.githubusercontent.com/6448364/222976588-97c50cea-e72c-4b8d-a1e5-451264a78b7e.png">

4. Commitne to zmeny
5. vytvori to nasledujuci tag napr `7.0.0`
6. vytvori to pre kazdu lib v monorepe prefixovany tag repozitarom napr `php-datatypes/7.0.0` podla verzie aka sa vydava
7. a thats it. 
Nasledne odkomenutjem pushovanie tagov takze ked v GH prejdem do noveho releasu a vyberem si verziu tak sa zavola GH ktore zavoal  `docker-compose run dev vendor/bin/monorepo-builder release <verzia>`  vytvoria sa v repozitare vsetky potrebne tagu a tie sa pushnu kde sa nasledne `split-repo.sh` postara o to aby sa jednotlive libky splitli spravne.


