### PR TITLE
Add stack prefix to GrantBucketAcces, remove branchId from revoke

### DIFF
--- a/packages/php-storage-driver-common/generated/GPBMetadata/Proto/Bucket.php
+++ b/packages/php-storage-driver-common/generated/GPBMetadata/Proto/Bucket.php
@@ -17,7 +17,7 @@ class Bucket
         \GPBMetadata\Google\Protobuf\Any::initOnce();
         $pool->internalAddGeneratedFile(
             '
-¡
+¤
 proto/bucket.proto$keboola.storageDriver.command.bucket"‚
 CreateBucketCommand
 stackPrefix (	
@@ -69,20 +69,20 @@ spoolSpace (	"D
 bucketObjectName (	
 bucketShareRoleName (	
 projectReadOnlyRoleName (	"
-meta (2.google.protobuf.Any"™
+meta (2.google.protobuf.Any"®
 &GrantBucketAccessToReadOnlyRoleCommand
 bucketObjectName (	
 projectReadOnlyRoleName (	"
 meta (2.google.protobuf.Any
-branchId (	"I
+branchId (	
+stackPrefix (	"I
 \'GrantBucketAccessToReadOnlyRoleResponse
-createBucketObjectName (	"²
+createBucketObjectName (	" 
 )RevokeBucketAccessFromReadOnlyRoleCommand
 bucketObjectName (	
 projectReadOnlyRoleName (	
 ignoreErrors ("
-meta (2.google.protobuf.Any
-branchId (	bproto3'
+meta (2.google.protobuf.Anybproto3'
         , true);
 
         static::$is_initialized = true;

--- a/packages/php-storage-driver-common/generated/Keboola/StorageDriver/Command/Bucket/GrantBucketAccessToReadOnlyRoleCommand.php
+++ b/packages/php-storage-driver-common/generated/Keboola/StorageDriver/Command/Bucket/GrantBucketAccessToReadOnlyRoleCommand.php
@@ -29,6 +29,10 @@ class GrantBucketAccessToReadOnlyRoleCommand extends \Google\Protobuf\Internal\M
      * Generated from protobuf field <code>string branchId = 4;</code>
      */
     protected $branchId = '';
+    /**
+     * Generated from protobuf field <code>string stackPrefix = 5;</code>
+     */
+    protected $stackPrefix = '';
 
     /**
      * Constructor.
@@ -40,6 +44,7 @@ class GrantBucketAccessToReadOnlyRoleCommand extends \Google\Protobuf\Internal\M
      *     @type string $projectReadOnlyRoleName
      *     @type \Google\Protobuf\Any $meta
      *     @type string $branchId
+     *     @type string $stackPrefix
      * }
      */
     public function __construct($data = NULL) {
@@ -141,6 +146,28 @@ class GrantBucketAccessToReadOnlyRoleCommand extends \Google\Protobuf\Internal\M
     {
         GPBUtil::checkString($var, True);
         $this->branchId = $var;
+
+        return $this;
+    }
+
+    /**
+     * Generated from protobuf field <code>string stackPrefix = 5;</code>
+     * @return string
+     */
+    public function getStackPrefix()
+    {
+        return $this->stackPrefix;
+    }
+
+    /**
+     * Generated from protobuf field <code>string stackPrefix = 5;</code>
+     * @param string $var
+     * @return $this
+     */
+    public function setStackPrefix($var)
+    {
+        GPBUtil::checkString($var, True);
+        $this->stackPrefix = $var;
 
         return $this;
     }

--- a/packages/php-storage-driver-common/generated/Keboola/StorageDriver/Command/Bucket/RevokeBucketAccessFromReadOnlyRoleCommand.php
+++ b/packages/php-storage-driver-common/generated/Keboola/StorageDriver/Command/Bucket/RevokeBucketAccessFromReadOnlyRoleCommand.php
@@ -37,10 +37,6 @@ class RevokeBucketAccessFromReadOnlyRoleCommand extends \Google\Protobuf\Interna
      * Generated from protobuf field <code>.google.protobuf.Any meta = 4;</code>
      */
     protected $meta = null;
-    /**
-     * Generated from protobuf field <code>string branchId = 5;</code>
-     */
-    protected $branchId = '';
 
     /**
      * Constructor.
@@ -56,7 +52,6 @@ class RevokeBucketAccessFromReadOnlyRoleCommand extends \Google\Protobuf\Interna
      *           if true all backend errors should be ignored and command will always pass
      *     @type \Google\Protobuf\Any $meta
      *           metadata specific for each backend
-     *     @type string $branchId
      * }
      */
     public function __construct($data = NULL) {
@@ -174,28 +169,6 @@ class RevokeBucketAccessFromReadOnlyRoleCommand extends \Google\Protobuf\Interna
     {
         GPBUtil::checkMessage($var, \Google\Protobuf\Any::class);
         $this->meta = $var;
-
-        return $this;
-    }
-
-    /**
-     * Generated from protobuf field <code>string branchId = 5;</code>
-     * @return string
-     */
-    public function getBranchId()
-    {
-        return $this->branchId;
-    }
-
-    /**
-     * Generated from protobuf field <code>string branchId = 5;</code>
-     * @param string $var
-     * @return $this
-     */
-    public function setBranchId($var)
-    {
-        GPBUtil::checkString($var, True);
-        $this->branchId = $var;
 
         return $this;
     }

--- a/packages/php-storage-driver-common/proto/bucket.proto
+++ b/packages/php-storage-driver-common/proto/bucket.proto
@@ -99,6 +99,7 @@ message GrantBucketAccessToReadOnlyRoleCommand {
   string projectReadOnlyRoleName = 2;
   google.protobuf.Any meta = 3;
   string branchId = 4;
+  string stackPrefix = 5;
 }
 
 /**
@@ -113,5 +114,4 @@ message RevokeBucketAccessFromReadOnlyRoleCommand {
   string projectReadOnlyRoleName = 2; // backend read only role associated with project
   bool ignoreErrors = 3; // if true all backend errors should be ignored and command will always pass
   google.protobuf.Any meta = 4; // metadata specific for each backend
-  string branchId = 5;
 }


### PR DESCRIPTION
Na zaklade https://github.com/keboola/php-storage-driver-bigquery/pull/48#discussion_r1314674297 musim pridat este stack prefix,

Zaroven odoberam z revoke branchId pretoze neiej potreba z connection dostanem cele schema name