### PR TITLE
BIG-185 Make more sense in BQ parsing exceptions

### DIFF
--- a/packages/php-table-backend-utils/src/Column/Bigquery/Parser/ComplexTypeTokenizer.php
+++ b/packages/php-table-backend-utils/src/Column/Bigquery/Parser/ComplexTypeTokenizer.php
@@ -34,6 +34,35 @@ final class ComplexTypeTokenizer
     private const T_COMPLEX_START = 'T_COMPLEX_START';
     // end of complex type >
     private const T_COMPLEX_END = 'T_COMPLEX_END';
+    private const REGEX_MATCH_TYPE = <<<EOD
+/ # Matches types ARRAY<> or types inside complex types INT, INT() ,...
+(\w+) # Match and capture one or more word characters
+# Match zero or more occurrences of the following non-capturing group
+(
+  # Start of non-capturing group
+  (?:           # Match the following, but don't capture it
+    <           # Match the opening angle bracket
+    .*          # Match any character (.) zero or more times (*) inside brackets
+    >           # Match the closing angle bracket
+  )             
+  *             # Match the non-capturing group zero or more times
+)
+/ix
+EOD;
+    private const REGEX_MATCH_NAME = <<<EOD
+/ # Name requires need space after it there is a space or end of string
+^ # Start at the beginning of the string
+[a-zA-Z0-9-_]+ # Match one or more alphanumeric characters, hyphens, or underscores
+(?=\s|$) # check for a space (\s) or the end of the string ($), but don't include it in the match
+/ix
+EOD;
+    private const REGEX_MATCH_LENGTH = <<<EOD
+/ # matches everything between () to get length of field
+\( # Match an opening parenthesis "("
+(.*?) # Match and capture any characters (.) non-greedily (*) within a pair of parentheses
+\) # Match a closing parenthesis ")"
+/x
+EOD;
 
     /**
      * @phpstan-return ArrayIterator<int, TokenizerToken|TokenizerNestedToken>
@@ -45,6 +74,8 @@ final class ComplexTypeTokenizer
         $length = strlen($input);
 
         $complexNestedLevel = 0;
+        $expectTypeNext = false;
+        $expectDelimiterOrCloseNext = false;
         while ($index < $length) {
             if ($input[$index] === ' ') {
                 // skip whitespace
@@ -56,12 +87,14 @@ final class ComplexTypeTokenizer
             if ($input[$index] === ',') {
                 // comma is only between fields in struct
                 $tokens->append(new TokenizerToken(self::T_FIELD_DELIMITER, ','));
+                $expectDelimiterOrCloseNext = false;
                 $index++;
                 continue;
             }
 
             if ($input[$index] === '<') {
                 // T_COMPLEX_START
+                $expectDelimiterOrCloseNext = false;
                 $tokens->append(new TokenizerTokenWithLevel(self::T_COMPLEX_START, '<', $complexNestedLevel));
                 $complexNestedLevel++;
                 $index++;
@@ -71,14 +104,23 @@ final class ComplexTypeTokenizer
             if ($input[$index] === '>') {
                 // T_COMPLEX_END
                 $complexNestedLevel--;
+                $expectDelimiterOrCloseNext = false;
                 $tokens->append(new TokenizerTokenWithLevel(self::T_COMPLEX_END, '>', $complexNestedLevel));
                 $index++;
                 continue;
             }
 
-            if (preg_match('/^[a-zA-Z0-9-_]+(?=\s|$)/i', substr($input, $index), $matchName, PREG_NO_ERROR)) {
+            if (preg_match(self::REGEX_MATCH_NAME, substr($input, $index), $matchName, PREG_NO_ERROR)) {
                 $positionCharacterAfter = $index + strlen($matchName[0]);
                 if ($length > $positionCharacterAfter && $input[$positionCharacterAfter] === ' ') {
+                    if ($expectTypeNext) {
+                        throw new ParsingComplexTypeLengthException(sprintf(
+                            'Unexpected token on position "%d" in "%s". Type of field expected.',
+                            $index,
+                            substr($input, $index)
+                        ));
+                    }
+                    $expectTypeNext = true;
                     // if next character is space, then this is T_NAME (name of column)
                     $tokens->append(new TokenizerToken(self::T_NAME, $matchName[0]));
                     $index += strlen($matchName[0]);
@@ -86,17 +128,27 @@ final class ComplexTypeTokenizer
                 }
             }
 
-            if (preg_match('/(\w+)(?:<.*>)*/', substr($input, $index), $matchType, PREG_NO_ERROR)) {
+            if (preg_match(self::REGEX_MATCH_TYPE, substr($input, $index), $matchType, PREG_NO_ERROR)) {
+                if ($expectDelimiterOrCloseNext) {
+                    throw new ParsingComplexTypeLengthException(sprintf(
+                        // phpcs:ignore
+                        'Unexpected token on position "%d" in "%s". Expected "," followed by next field or end of ARRAY|STRUCT.',
+                        $index,
+                        substr($input, $index)
+                    ));
+                }
+                $expectTypeNext = false;
+                $expectDelimiterOrCloseNext = true;
                 $tokens->append(new TokenizerToken(self::T_TYPE, $matchType[1]));
                 $index += strlen($matchType[1]);
                 // check type followed by length definition
                 if ($length > $index && $input[$index] === '(') {
                     // length start
-                    if (preg_match('/\((.*?)\)/', substr($input, $index), $matchLength)) {
+                    if (preg_match(self::REGEX_MATCH_LENGTH, substr($input, $index), $matchLength)) {
                         $tokens->append(new TokenizerToken(self::T_LENGTH, $matchLength[1]));
                         $index += strlen($matchLength[1]) + 2; // skip content + 2 ()
                     } else {
-                        throw new RuntimeException(sprintf(
+                        throw new ParsingComplexTypeLengthException(sprintf(
                             'Unexpected token on position "%d" in "%s". Closing parenthesis not found.',
                             $index,
                             substr($input, $index)
@@ -106,7 +158,7 @@ final class ComplexTypeTokenizer
                 continue;
             }
 
-            throw new RuntimeException(sprintf(
+            throw new ParsingComplexTypeLengthException(sprintf(
                 'Unexpected token "%s" on position "%d" in "%s"',
                 $input[$index],
                 $index,

--- a/packages/php-table-backend-utils/src/Column/Bigquery/Parser/ComplexTypeTokenizer.php
+++ b/packages/php-table-backend-utils/src/Column/Bigquery/Parser/ComplexTypeTokenizer.php
@@ -36,31 +36,31 @@ final class ComplexTypeTokenizer
     private const T_COMPLEX_END = 'T_COMPLEX_END';
     private const REGEX_MATCH_TYPE = <<<EOD
 / # Matches types ARRAY<> or types inside complex types INT, INT() ,...
-(\w+) # Match and capture one or more word characters
+(\w+)  # Match and capture one or more word characters
 # Match zero or more occurrences of the following non-capturing group
 (
   # Start of non-capturing group
-  (?:           # Match the following, but don't capture it
-    <           # Match the opening angle bracket
-    .*          # Match any character (.) zero or more times (*) inside brackets
-    >           # Match the closing angle bracket
+  (?:  # Match the following, but don't capture it
+    <  # Match the opening angle bracket
+    .* # Match any character (.) zero or more times (*) inside brackets
+    >  # Match the closing angle bracket
   )             
-  *             # Match the non-capturing group zero or more times
+  *  # Match the non-capturing group zero or more times
 )
 /ix
 EOD;
     private const REGEX_MATCH_NAME = <<<EOD
 / # Name requires need space after it there is a space or end of string
-^ # Start at the beginning of the string
-[a-zA-Z0-9-_]+ # Match one or more alphanumeric characters, hyphens, or underscores
-(?=\s|$) # check for a space (\s) or the end of the string ($), but don't include it in the match
+^                # Start at the beginning of the string
+[a-zA-Z0-9-_]+   # Match one or more alphanumeric characters, hyphens, or underscores
+(?=\s|$)         # check for a space (\s) or the end of the string ($), but don't include it in the match
 /ix
 EOD;
     private const REGEX_MATCH_LENGTH = <<<EOD
 / # matches everything between () to get length of field
-\( # Match an opening parenthesis "("
+\(    # Match an opening parenthesis "("
 (.*?) # Match and capture any characters (.) non-greedily (*) within a pair of parentheses
-\) # Match a closing parenthesis ")"
+\)    # Match a closing parenthesis ")"
 /x
 EOD;
 

--- a/packages/php-table-backend-utils/src/Column/Bigquery/Parser/ParsingComplexTypeLengthException.php
+++ b/packages/php-table-backend-utils/src/Column/Bigquery/Parser/ParsingComplexTypeLengthException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\TableBackendUtils\Column\Bigquery\Parser;
+
+use RuntimeException;
+
+class ParsingComplexTypeLengthException extends RuntimeException
+{
+}

--- a/packages/php-table-backend-utils/src/Connection/Bigquery/BigQueryClientHandler.php
+++ b/packages/php-table-backend-utils/src/Connection/Bigquery/BigQueryClientHandler.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\TableBackendUtils\Connection\Bigquery;
+
+use GuzzleHttp\Client;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Retry\BackOff\UniformRandomBackOffPolicy;
+use Retry\Policy\SimpleRetryPolicy;
+use Retry\RetryProxy;
+
+/**
+ * Guzzle http handler for BigQuery client with retry policy
+ */
+class BigQueryClientHandler
+{
+    private Client $client;
+
+    public function __construct(Client $client)
+    {
+        $this->client = $client;
+    }
+
+    public function __invoke(RequestInterface $request): ResponseInterface
+    {
+        $retryPolicy = new SimpleRetryPolicy(5);
+        $proxy = new RetryProxy($retryPolicy, new UniformRandomBackOffPolicy());
+
+        /** @var ResponseInterface $result */
+        $result = $proxy->call(function () use ($request) {
+            return $this->client->send($request);
+        });
+        return $result;
+    }
+}

--- a/packages/php-table-backend-utils/tests/Functional/Bigquery/BigqueryBaseCase.php
+++ b/packages/php-table-backend-utils/tests/Functional/Bigquery/BigqueryBaseCase.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Tests\Keboola\TableBackendUtils\Functional\Bigquery;
 
 use Google\Cloud\BigQuery\BigQueryClient;
+use GuzzleHttp\Client;
+use Keboola\TableBackendUtils\Connection\Bigquery\BigQueryClientHandler;
 use Keboola\TableBackendUtils\Escaping\Bigquery\BigqueryQuote;
 use LogicException;
 use PHPUnit\Framework\TestCase;
@@ -44,6 +46,7 @@ class BigqueryBaseCase extends TestCase
 
     /**
      * Get credentials from envs
+     *
      * @return array<string, string>
      */
     protected function getCredentials(): array
@@ -88,6 +91,7 @@ class BigqueryBaseCase extends TestCase
     {
         return new BigQueryClient([
             'keyFile' => $this->getCredentials(),
+            'httpHandler' => new BigQueryClientHandler(new Client()),
         ]);
     }
 


### PR DESCRIPTION
JIRA: BIG-185

- Upravil sem chybové hlášky aby dávali víc smysl a aby sa vyhazovala InvalidLengthException z php-datatypes.
- přidal sem unit testy na chybové stavy, ne všecky exceptions sa mě podařilo vynutit, ale sů to reálně chybové stavy, které by mohli nějak nastat