### PR TITLE
BIG-193 catch service exception

### DIFF
--- a/packages/php-db-import-export/src/Backend/Bigquery/BigqueryException.php
+++ b/packages/php-db-import-export/src/Backend/Bigquery/BigqueryException.php
@@ -13,7 +13,27 @@ class BigqueryException extends Exception
 {
     public static function covertException(JobException|ServiceException $e): Throwable
     {
-        // TODO
+        if ($e instanceof ServiceException) {
+            return new self($e->getMessage());
+        }
         return $e;
     }
+
+    public static function createExceptionFromJobResult(array $jobInfo): Throwable
+    {
+        $errorMessage = $jobInfo['status']['errorResult']['message'] ?? 'Unknown error';
+
+        // detecting missing required column. Record with `Required column value is missing` substring contains
+        // much better information for enduser
+        foreach ($jobInfo['status']['errors'] ?? [] as $error) {
+            if (str_contains($error['message'], 'Required column value is missing')) {
+                $errorMessage = $error['message'];
+                break;
+            }
+        }
+
+        return new self($errorMessage);
+    }
 }
+
+

--- a/packages/php-db-import-export/src/Backend/Bigquery/BigqueryException.php
+++ b/packages/php-db-import-export/src/Backend/Bigquery/BigqueryException.php
@@ -14,6 +14,9 @@ class BigqueryException extends Exception
     public static function covertException(JobException|ServiceException $e): Throwable
     {
         if ($e instanceof ServiceException) {
+            if (str_contains($e->getMessage(), 'Required column value is missing')) {
+                return new BigqueryInputDataException($e->getMessage());
+            }
             return new self($e->getMessage());
         }
         return $e;
@@ -28,7 +31,7 @@ class BigqueryException extends Exception
         foreach ($jobInfo['status']['errors'] ?? [] as $error) {
             if (str_contains($error['message'], 'Required column value is missing')) {
                 $errorMessage = $error['message'];
-                break;
+                return new BigqueryInputDataException($errorMessage);
             }
         }
 

--- a/packages/php-db-import-export/src/Backend/Bigquery/BigqueryException.php
+++ b/packages/php-db-import-export/src/Backend/Bigquery/BigqueryException.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 namespace Keboola\Db\ImportExport\Backend\Bigquery;
 
 use Google\Cloud\BigQuery\Exception\JobException;
+use Google\Cloud\Core\Exception\ServiceException;
 use Keboola\Db\Import\Exception;
 use Throwable;
 
 class BigqueryException extends Exception
 {
-    public static function covertException(JobException $e): Throwable
+    public static function covertException(JobException|ServiceException $e): Throwable
     {
         // TODO
         return $e;

--- a/packages/php-db-import-export/src/Backend/Bigquery/BigqueryException.php
+++ b/packages/php-db-import-export/src/Backend/Bigquery/BigqueryException.php
@@ -14,7 +14,7 @@ class BigqueryException extends Exception
     public static function covertException(JobException|ServiceException $e): Throwable
     {
         if ($e instanceof ServiceException) {
-            if (str_contains($e->getMessage(), 'Required column value is missing')) {
+            if (preg_match('/.*Required field .+ cannot be null.*/m', $e->getMessage(), $output_array) === 1) {
                 return new BigqueryInputDataException($e->getMessage());
             }
             return new self($e->getMessage());

--- a/packages/php-db-import-export/src/Backend/Bigquery/BigqueryInputDataException.php
+++ b/packages/php-db-import-export/src/Backend/Bigquery/BigqueryInputDataException.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\Db\ImportExport\Backend\Bigquery;
+
+/**
+ * unretriable error during import
+ */
+class BigqueryInputDataException extends BigqueryException
+{
+}
+
+

--- a/packages/php-db-import-export/src/Backend/Bigquery/ToStage/FromGCSCopyIntoAdapter.php
+++ b/packages/php-db-import-export/src/Backend/Bigquery/ToStage/FromGCSCopyIntoAdapter.php
@@ -6,7 +6,7 @@ namespace Keboola\Db\ImportExport\Backend\Bigquery\ToStage;
 
 use Exception;
 use Google\Cloud\BigQuery\BigQueryClient;
-use Google\Cloud\Core\Exception\BadRequestException;
+use Keboola\Db\ImportExport\Backend\Bigquery\BigqueryException;
 use Keboola\Db\ImportExport\Backend\CopyAdapterInterface;
 use Keboola\Db\ImportExport\ImportOptions;
 use Keboola\Db\ImportExport\ImportOptionsInterface;
@@ -77,8 +77,7 @@ class FromGCSCopyIntoAdapter implements CopyAdapterInterface
         }
         // check if the job has errors
         if (isset($job->info()['status']['errorResult'])) {
-            $error = $job->info()['status']['errorResult']['message'];
-            throw new BadRequestException($error);
+            throw BigqueryException::createExceptionFromJobResult($job->info());
         }
 
         $ref = new BigqueryTableReflection(

--- a/packages/php-db-import-export/src/Backend/Bigquery/ToStage/ToStageImporter.php
+++ b/packages/php-db-import-export/src/Backend/Bigquery/ToStage/ToStageImporter.php
@@ -6,6 +6,7 @@ namespace Keboola\Db\ImportExport\Backend\Bigquery\ToStage;
 
 use Google\Cloud\BigQuery\BigQueryClient;
 use Google\Cloud\BigQuery\Exception\JobException;
+use Google\Cloud\Core\Exception\ServiceException;
 use Keboola\Db\ImportExport\Backend\Bigquery\BigqueryException;
 use Keboola\Db\ImportExport\Backend\CopyAdapterInterface;
 use Keboola\Db\ImportExport\Backend\ImportState;
@@ -48,7 +49,7 @@ final class ToStageImporter implements ToStageImporterInterface
                     $options
                 )
             );
-        } catch (JobException $e) {
+        } catch (JobException|ServiceException $e) {
             throw BigqueryException::covertException($e);
         }
         $state->stopTimer(self::TIMER_TABLE_IMPORT);

--- a/packages/php-db-import-export/tests/functional/Bigquery/StageImportTest.php
+++ b/packages/php-db-import-export/tests/functional/Bigquery/StageImportTest.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Tests\Keboola\Db\ImportExportFunctional\Bigquery;
 
 use Google\Cloud\Core\Exception\BadRequestException;
-use Google\Cloud\Core\Exception\ServiceException;
 use Keboola\CsvOptions\CsvOptions;
 use Keboola\Db\ImportExport\Backend\Bigquery\BigqueryException;
 use Keboola\Db\ImportExport\Backend\Bigquery\ToStage\ToStageImporter;
+use Keboola\Db\ImportExport\Storage\Bigquery\Table;
 use Keboola\TableBackendUtils\Escaping\Bigquery\BigqueryQuote;
 use Keboola\TableBackendUtils\Schema\Bigquery\BigquerySchemaReflection;
 use Keboola\TableBackendUtils\Table\Bigquery\BigqueryTableReflection;
@@ -169,10 +169,10 @@ class StageImportTest extends BigqueryBaseTestCase
         }
     }
 
-    public function testLoadNullToRequiredColumn(): void
+    public function testLoadFromFileWithNullValueToRequiredColumn(): void
     {
         $query = $this->bqClient->query(
-        // table is one column short - import should fail
+        // name is NOT NULL, but nullify file contains null value for this column
             sprintf(
                 'CREATE TABLE %s.%s
      (
@@ -207,11 +207,90 @@ class StageImportTest extends BigqueryBaseTestCase
             self::fail('should fail');
         } catch (Throwable $e) {
             $this->assertInstanceOf(BigqueryException::class, $e);
-            $this->assertEquals('lalal', $e->getMessage());
-            // nor target table nor LOG/ERR tables should be present
-            $scheRef = new BigquerySchemaReflection($this->bqClient, self::TEST_DATABASE);
-            $tables = $scheRef->getTablesNames();
-            self::assertCount(1, $tables); // table should be present, only import fails
+            $this->assertStringContainsString('Required column value is missing', $e->getMessage());
+        }
+    }
+
+    public function testLoadFromTableWithNullValueToRequiredColumn(): void
+    {
+        $sourceTable = self::TABLE_GENERIC . '_source';
+        $destinationTable = self::TABLE_GENERIC . '_dest';
+
+        $destinationPath = [
+            BigqueryQuote::quoteSingleIdentifier(self::TEST_DATABASE),
+            BigqueryQuote::quoteSingleIdentifier($destinationTable),
+        ];
+        $sourcePath = [
+            BigqueryQuote::quoteSingleIdentifier(self::TEST_DATABASE),
+            BigqueryQuote::quoteSingleIdentifier($sourceTable),
+        ];
+
+        // create destination with NOT NULL
+        $query = $this->bqClient->query(
+            sprintf(
+                'CREATE TABLE %s.%s
+     (
+      `id` INT64 NOT NULL,
+      `name` STRING(100) NOT NULL,
+      `price` STRING(100)
+     );',
+                ...$destinationPath
+            )
+        );
+        $this->bqClient->runQuery($query);
+
+        // create source table
+        $query = $this->bqClient->query(
+        // table is one column short - import should fail
+            sprintf(
+                'CREATE TABLE %s.%s
+     (
+      `id` INT64 NOT NULL,
+      `name` STRING(100),
+      `price` STRING(100)
+     );',
+                ...$sourcePath
+            )
+        );
+        $this->bqClient->runQuery($query);
+
+        // load source table with some NULLs
+        $query = $this->bqClient->query(
+            sprintf(
+                'INSERT INTO %s.%s VALUES (1, NULL, \'1000\');',
+                ...$sourcePath
+            )
+        );
+        $this->bqClient->runQuery($query);
+
+        $importer = new ToStageImporter($this->bqClient);
+        $ref = new BigqueryTableReflection(
+            $this->bqClient,
+            self::TEST_DATABASE,
+            $destinationTable
+        );
+
+        try {
+            // load SOURCE which contains NULL to DESTINATION which has NOT NULL column
+            $importer->importToStagingTable(
+                new Table(
+                    self::TEST_DATABASE,
+                    $sourceTable,
+                    [],
+                    [],
+                ),
+                $ref->getTableDefinition(),
+                $this->getImportOptions(
+                    [],
+                    false,
+                    false,
+                    1
+                )
+            );
+            self::fail('should fail');
+        } catch (Throwable $e) {
+            $this->assertInstanceOf(BigqueryException::class, $e);
+            $this->assertStringContainsString('Required field name cannot be null', $e->getMessage());
         }
     }
 }

--- a/packages/php-db-import-export/tests/functional/Bigquery/StageImportTest.php
+++ b/packages/php-db-import-export/tests/functional/Bigquery/StageImportTest.php
@@ -6,7 +6,7 @@ namespace Tests\Keboola\Db\ImportExportFunctional\Bigquery;
 
 use Google\Cloud\Core\Exception\BadRequestException;
 use Keboola\CsvOptions\CsvOptions;
-use Keboola\Db\ImportExport\Backend\Bigquery\BigqueryException;
+use Keboola\Db\ImportExport\Backend\Bigquery\BigqueryInputDataException;
 use Keboola\Db\ImportExport\Backend\Bigquery\ToStage\ToStageImporter;
 use Keboola\Db\ImportExport\Storage\Bigquery\Table;
 use Keboola\TableBackendUtils\Escaping\Bigquery\BigqueryQuote;
@@ -206,8 +206,7 @@ class StageImportTest extends BigqueryBaseTestCase
             );
             self::fail('should fail');
         } catch (Throwable $e) {
-            $this->assertInstanceOf(BigqueryException::class, $e);
-            $this->assertStringContainsString('Required column value is missing', $e->getMessage());
+            $this->assertInstanceOf(BigqueryInputDataException::class, $e);
         }
     }
 
@@ -289,8 +288,7 @@ class StageImportTest extends BigqueryBaseTestCase
             );
             self::fail('should fail');
         } catch (Throwable $e) {
-            $this->assertInstanceOf(BigqueryException::class, $e);
-            $this->assertStringContainsString('Required field name cannot be null', $e->getMessage());
+            $this->assertInstanceOf(BigqueryInputDataException::class, $e);
         }
     }
 }

--- a/packages/php-db-import-export/tests/functional/Bigquery/StageImportTest.php
+++ b/packages/php-db-import-export/tests/functional/Bigquery/StageImportTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Keboola\Db\ImportExportFunctional\Bigquery;
 
-use Google\Cloud\Core\Exception\BadRequestException;
 use Keboola\CsvOptions\CsvOptions;
+use Keboola\Db\ImportExport\Backend\Bigquery\BigqueryException;
 use Keboola\Db\ImportExport\Backend\Bigquery\BigqueryInputDataException;
 use Keboola\Db\ImportExport\Backend\Bigquery\ToStage\ToStageImporter;
 use Keboola\Db\ImportExport\Storage\Bigquery\Table;
@@ -161,7 +161,7 @@ class StageImportTest extends BigqueryBaseTestCase
                 )
             );
             self::fail('should fail');
-        } catch (BadRequestException $e) {
+        } catch (BigqueryException $e) {
             // nor target table nor LOG/ERR tables should be present
             $scheRef = new BigquerySchemaReflection($this->bqClient, self::TEST_DATABASE);
             $tables = $scheRef->getTablesNames();


### PR DESCRIPTION
Jira: BIG-193

Odchytavam exception, kdyz to chcipne na loadu null do not-null sloupce. Je to ve dvou usecasech (job a query) a chci k tomu vratit BigqueryInputDataException abych podle ni pak mohl v driveru vratit `ImportValidationException` ktera ma `NonRetryableExceptionInterface` (nedava smysl retry kdyz loadujes spatna data)

s tema exceptions lib-driver-connection je bordel, vubec se mi ta situace nelibi