### PR TITLE
CT-1642 Fix support for GEOMETRY and GEOGRAPHY for incremental load

### DIFF
--- a/packages/php-db-import-export/src/Backend/Snowflake/ToFinalTable/SqlBuilder.php
+++ b/packages/php-db-import-export/src/Backend/Snowflake/ToFinalTable/SqlBuilder.php
@@ -369,11 +369,22 @@ class SqlBuilder
             case $importOptions->compareAllColumnsInNativeTable():
                 foreach ($stagingTableDefinition->getColumnsDefinitions() as $sourceColumn) {
                     $destinationColumn = $columnMap->getDestination($sourceColumn);
-                    $columnsComparisonSql[] = sprintf(
-                        '"dest".%s IS DISTINCT FROM "src".%s',
-                        SnowflakeQuote::quoteSingleIdentifier($destinationColumn->getColumnName()),
-                        SnowflakeQuote::quoteSingleIdentifier($sourceColumn->getColumnName()),
-                    );
+                    if (in_array($destinationColumn->getColumnDefinition()->getType(), [
+                        Snowflake::TYPE_GEOGRAPHY,
+                        Snowflake::TYPE_GEOMETRY,
+                    ], true)) {
+                        $columnsComparisonSql[] = sprintf(
+                            'ST_ASEWKT("dest".%s) IS DISTINCT FROM ST_ASEWKT("src".%s)',
+                            SnowflakeQuote::quoteSingleIdentifier($destinationColumn->getColumnName()),
+                            SnowflakeQuote::quoteSingleIdentifier($sourceColumn->getColumnName()),
+                        );
+                    } else {
+                        $columnsComparisonSql[] = sprintf(
+                            '"dest".%s IS DISTINCT FROM "src".%s',
+                            SnowflakeQuote::quoteSingleIdentifier($destinationColumn->getColumnName()),
+                            SnowflakeQuote::quoteSingleIdentifier($sourceColumn->getColumnName()),
+                        );
+                    }
                 }
                 break;
         }

--- a/packages/php-db-import-export/src/Backend/Snowflake/ToFinalTable/SqlBuilder.php
+++ b/packages/php-db-import-export/src/Backend/Snowflake/ToFinalTable/SqlBuilder.php
@@ -367,16 +367,15 @@ class SqlBuilder
                 );
                 break;
             case $importOptions->compareAllColumnsInNativeTable():
-                $columnsComparisonSql = array_map(
-                    static function ($columnName) {
-                        return sprintf(
-                            '"dest".%s IS DISTINCT FROM "src".%s',
-                            SnowflakeQuote::quoteSingleIdentifier($columnName),
-                            SnowflakeQuote::quoteSingleIdentifier($columnName),
-                        );
-                    },
-                    $stagingTableDefinition->getColumnsNames(),
-                );
+                foreach ($stagingTableDefinition->getColumnsDefinitions() as $sourceColumn) {
+                    $destinationColumn = $columnMap->getDestination($sourceColumn);
+                    $columnsComparisonSql[] = sprintf(
+                        '"dest".%s IS DISTINCT FROM "src".%s',
+                        SnowflakeQuote::quoteSingleIdentifier($destinationColumn->getColumnName()),
+                        SnowflakeQuote::quoteSingleIdentifier($sourceColumn->getColumnName()),
+                    );
+                }
+                break;
         }
 
         $dest = sprintf(


### PR DESCRIPTION
Jira: CT-1642
Connection PR: XXX
SAPI PR: XXX

---

`getUpdateWithPkCommand` now can compare GEOMETRY and GEOGRAPHY datatypes, previously it was wrong and query would fail as DISTINCT FROM cannot compare two same types.
Not it will cast them to EWKT and compare with DISTINCT FROM