### PR TITLE
New version of php-datatypes lib

### DIFF
--- a/packages/php-table-backend-utils/composer.json
+++ b/packages/php-table-backend-utils/composer.json
@@ -16,7 +16,7 @@
         "doctrine/dbal": "^3.3",
         "google/cloud-bigquery": "^1.23",
         "keboola/common-exceptions": "^1",
-        "keboola/php-datatypes": "^7.6",
+        "keboola/php-datatypes": "^8.0",
         "keboola/php-utils": "^4.1",
         "keboola/retry": "^0.5.0"
     },


### PR DESCRIPTION
Protože tady https://github.com/keboola/data-loader-api/blob/e23d4bf36062d356d49b8b4944e423dd62f1a67e/composer.json#L29 se používá php-data-types i table-backend-utils.

Jira: https://keboola.atlassian.net/browse/KAB-312
Connection PR: XXX
SAPI PR: XXX

---
