### PR TITLE
CT-1424 remove dependency on native types feature

### DIFF
--- a/packages/php-db-import-export/src/Backend/Bigquery/ToFinalTable/SqlBuilder.php
+++ b/packages/php-db-import-export/src/Backend/Bigquery/ToFinalTable/SqlBuilder.php
@@ -319,36 +319,22 @@ SQL,
             );
         }
 
-        $columnsComparisonSql = [];
-        if ($importOptions->compareAllColumnsInNativeTable()) {
-            $columnsComparisonSql = array_map(
-                static function ($columnName) {
-                    return sprintf(
-                        '`dest`.%s IS DISTINCT FROM `src`.%s',
-                        BigqueryQuote::quoteSingleIdentifier($columnName),
-                        BigqueryQuote::quoteSingleIdentifier($columnName),
-                    );
-                },
-                $stagingTableDefinition->getColumnsNames(),
-            );
-        }
+        $columnsComparisonSql = array_map(
+            static function ($columnName) {
+                return sprintf(
+                    '`dest`.%s IS DISTINCT FROM `src`.%s',
+                    BigqueryQuote::quoteSingleIdentifier($columnName),
+                    BigqueryQuote::quoteSingleIdentifier($columnName),
+                );
+            },
+            $stagingTableDefinition->getColumnsNames(),
+        );
 
         $dest = sprintf(
             '%s.%s',
             BigqueryQuote::quoteSingleIdentifier($destinationTableDefinition->getSchemaName()),
             BigqueryQuote::quoteSingleIdentifier($destinationTableDefinition->getTableName()),
         );
-
-        if ($columnsComparisonSql === []) {
-            return sprintf(
-                'UPDATE %s AS `dest` SET %s FROM %s.%s AS `src` WHERE %s',
-                $dest,
-                implode(', ', $columnsSet),
-                BigqueryQuote::quoteSingleIdentifier($stagingTableDefinition->getSchemaName()),
-                BigqueryQuote::quoteSingleIdentifier($stagingTableDefinition->getTableName()),
-                $this->getPrimaryKeyWhereConditions($destinationTableDefinition->getPrimaryKeysNames(), $importOptions),
-            );
-        }
 
         return sprintf(
             'UPDATE %s AS `dest` SET %s FROM %s.%s AS `src` WHERE %s AND (%s)',

--- a/packages/php-db-import-export/src/Backend/Snowflake/ToFinalTable/SqlBuilder.php
+++ b/packages/php-db-import-export/src/Backend/Snowflake/ToFinalTable/SqlBuilder.php
@@ -389,41 +389,38 @@ class SqlBuilder
         }
 
         $columnsComparisonSql = [];
-        switch (true) {
-            case $importOptions->isNullManipulationEnabled():
-                // update only changed rows - mysql TIMESTAMP ON UPDATE behaviour simulation
-                $columnsComparisonSql = array_map(
-                    static function ($columnName) {
-                        return sprintf(
-                            'COALESCE(TO_VARCHAR("dest".%s), \'\') != COALESCE("src".%s, \'\')',
-                            SnowflakeQuote::quoteSingleIdentifier($columnName),
-                            SnowflakeQuote::quoteSingleIdentifier($columnName),
-                        );
-                    },
-                    $stagingTableDefinition->getColumnsNames(),
-                );
-                break;
-            case $importOptions->compareAllColumnsInNativeTable():
-                foreach ($stagingTableDefinition->getColumnsDefinitions() as $sourceColumn) {
-                    $destinationColumn = $columnMap->getDestination($sourceColumn);
-                    if (in_array($destinationColumn->getColumnDefinition()->getType(), [
-                        Snowflake::TYPE_GEOGRAPHY,
-                        Snowflake::TYPE_GEOMETRY,
-                    ], true)) {
-                        $columnsComparisonSql[] = sprintf(
-                            'ST_ASEWKT("dest".%s) IS DISTINCT FROM ST_ASEWKT("src".%s)',
-                            SnowflakeQuote::quoteSingleIdentifier($destinationColumn->getColumnName()),
-                            SnowflakeQuote::quoteSingleIdentifier($sourceColumn->getColumnName()),
-                        );
-                    } else {
-                        $columnsComparisonSql[] = sprintf(
-                            '"dest".%s IS DISTINCT FROM "src".%s',
-                            SnowflakeQuote::quoteSingleIdentifier($destinationColumn->getColumnName()),
-                            SnowflakeQuote::quoteSingleIdentifier($sourceColumn->getColumnName()),
-                        );
-                    }
+        if ($importOptions->isNullManipulationEnabled()) {
+            // update only changed rows - mysql TIMESTAMP ON UPDATE behaviour simulation
+            $columnsComparisonSql = array_map(
+                static function ($columnName) {
+                    return sprintf(
+                        'COALESCE(TO_VARCHAR("dest".%s), \'\') != COALESCE("src".%s, \'\')',
+                        SnowflakeQuote::quoteSingleIdentifier($columnName),
+                        SnowflakeQuote::quoteSingleIdentifier($columnName),
+                    );
+                },
+                $stagingTableDefinition->getColumnsNames(),
+            );
+        } else {
+            foreach ($stagingTableDefinition->getColumnsDefinitions() as $sourceColumn) {
+                $destinationColumn = $columnMap->getDestination($sourceColumn);
+                if (in_array($destinationColumn->getColumnDefinition()->getType(), [
+                    Snowflake::TYPE_GEOGRAPHY,
+                    Snowflake::TYPE_GEOMETRY,
+                ], true)) {
+                    $columnsComparisonSql[] = sprintf(
+                        'ST_ASEWKT("dest".%s) IS DISTINCT FROM ST_ASEWKT("src".%s)',
+                        SnowflakeQuote::quoteSingleIdentifier($destinationColumn->getColumnName()),
+                        SnowflakeQuote::quoteSingleIdentifier($sourceColumn->getColumnName()),
+                    );
+                } else {
+                    $columnsComparisonSql[] = sprintf(
+                        '"dest".%s IS DISTINCT FROM "src".%s',
+                        SnowflakeQuote::quoteSingleIdentifier($destinationColumn->getColumnName()),
+                        SnowflakeQuote::quoteSingleIdentifier($sourceColumn->getColumnName()),
+                    );
                 }
-                break;
+            }
         }
 
         $dest = sprintf(

--- a/packages/php-db-import-export/src/ImportOptions.php
+++ b/packages/php-db-import-export/src/ImportOptions.php
@@ -100,15 +100,4 @@ class ImportOptions implements ImportOptionsInterface
     {
         return $this->features;
     }
-
-    public function compareAllColumnsInNativeTable(): bool
-    {
-        if (in_array('new-native-types', $this->features, true)
-            ||
-            in_array('native-types_timestamp-bc', $this->features, true)
-        ) {
-            return true;
-        }
-        return false;
-    }
 }

--- a/packages/php-db-import-export/src/ImportOptionsInterface.php
+++ b/packages/php-db-import-export/src/ImportOptionsInterface.php
@@ -41,9 +41,4 @@ interface ImportOptionsInterface
      * @return string[]
      */
     public function features(): array;
-
-    /**
-     * Allowed for specific features
-     */
-    public function compareAllColumnsInNativeTable(): bool;
 }

--- a/packages/php-db-import-export/tests/functional/Bigquery/BigqueryBaseTestCase.php
+++ b/packages/php-db-import-export/tests/functional/Bigquery/BigqueryBaseTestCase.php
@@ -83,7 +83,7 @@ class BigqueryBaseTestCase extends ImportExportBaseTest
     protected function getSourceDbName(): string
     {
         /** @var string $suitePrefixEnv */
-        $suitePrefixEnv = getenv('SUITE');
+        $suitePrefixEnv = getenv('SUITE') ?: '';
         return self::BIGQUERY_SOURCE_DATABASE_NAME
             . '_'
             . str_replace('-', '_', $suitePrefixEnv);
@@ -92,7 +92,7 @@ class BigqueryBaseTestCase extends ImportExportBaseTest
     protected function getDestinationDbName(): string
     {
         /** @var string $suitePrefixEnv */
-        $suitePrefixEnv = getenv('SUITE');
+        $suitePrefixEnv = getenv('SUITE') ?: '';
         return self::BIGQUERY_DESTINATION_DATABASE_NAME
             . '_'
             . str_replace('-', '_', $suitePrefixEnv);

--- a/packages/php-db-import-export/tests/functional/Bigquery/SqlBuildTest.php
+++ b/packages/php-db-import-export/tests/functional/Bigquery/SqlBuildTest.php
@@ -813,14 +813,8 @@ class SqlBuildTest extends BigqueryBaseTestCase
 
     public function nullManipulationWithTimestampFeatures(): Generator
     {
-        yield 'new-native-types' => [
-            'new-native-types',
-            // phpcs:ignore
-            'UPDATE `import_export_test_schema`.`import_export_test_test` AS `dest` SET `col1` = `src`.`col1`, `col2` = `src`.`col2`, `_timestamp` = \'2020-01-01 01:01:01\' FROM `import_export_test_schema`.`stagingTable` AS `src` WHERE `dest`.`col1` = `src`.`col1`  AND (`dest`.`col1` IS DISTINCT FROM `src`.`col1` OR `dest`.`col2` IS DISTINCT FROM `src`.`col2`)',
-            false,
-        ];
-        yield 'native-types_timestamp-bc' => [
-            'native-types_timestamp-bc',
+        yield 'default' => [
+            'default',
             // phpcs:ignore
             'UPDATE `import_export_test_schema`.`import_export_test_test` AS `dest` SET `col1` = `src`.`col1`, `col2` = `src`.`col2`, `_timestamp` = \'2020-01-01 01:01:01\' FROM `import_export_test_schema`.`stagingTable` AS `src` WHERE `dest`.`col1` = `src`.`col1`  AND (`dest`.`col1` IS DISTINCT FROM `src`.`col1` OR `dest`.`col2` IS DISTINCT FROM `src`.`col2`)',
             false,

--- a/packages/php-db-import-export/tests/functional/Bigquery/SqlBuildTest.php
+++ b/packages/php-db-import-export/tests/functional/Bigquery/SqlBuildTest.php
@@ -703,12 +703,12 @@ class SqlBuildTest extends BigqueryBaseTestCase
         yield 'typed' => [ // nothing is converted
             BigqueryImportOptions::USING_TYPES_USER,
             // phpcs:ignore
-            'UPDATE `import_export_test_schema`.`import_export_test_test` AS `dest` SET `col1` = `src`.`col1`, `col2` = `src`.`col2`, `_timestamp` = \'2020-01-01 01:01:01\' FROM `import_export_test_schema`.`stagingTable` AS `src` WHERE `dest`.`col1` = `src`.`col1` ',
+            'UPDATE `import_export_test_schema`.`import_export_test_test` AS `dest` SET `col1` = `src`.`col1`, `col2` = `src`.`col2`, `_timestamp` = \'2020-01-01 01:01:01\' FROM `import_export_test_schema`.`stagingTable` AS `src` WHERE `dest`.`col1` = `src`.`col1`  AND (`dest`.`col1` IS DISTINCT FROM `src`.`col1` OR `dest`.`col2` IS DISTINCT FROM `src`.`col2`)',
         ];
         yield 'string' => [
             BigqueryImportOptions::USING_TYPES_STRING,
             // phpcs:ignore
-            'UPDATE `import_export_test_schema`.`import_export_test_test` AS `dest` SET `col1` = IF(`src`.`col1` = \'\', NULL, `src`.`col1`), `col2` = COALESCE(`src`.`col2`, \'\'), `_timestamp` = \'2020-01-01 01:01:01\' FROM `import_export_test_schema`.`stagingTable` AS `src` WHERE `dest`.`col1` = COALESCE(`src`.`col1`, \'\') ',
+            'UPDATE `import_export_test_schema`.`import_export_test_test` AS `dest` SET `col1` = IF(`src`.`col1` = \'\', NULL, `src`.`col1`), `col2` = COALESCE(`src`.`col2`, \'\'), `_timestamp` = \'2020-01-01 01:01:01\' FROM `import_export_test_schema`.`stagingTable` AS `src` WHERE `dest`.`col1` = COALESCE(`src`.`col1`, \'\')  AND (`dest`.`col1` IS DISTINCT FROM `src`.`col1` OR `dest`.`col2` IS DISTINCT FROM `src`.`col2`)',
         ];
     }
 

--- a/packages/php-db-import-export/tests/functional/Bigquery/SqlBuildTest.php
+++ b/packages/php-db-import-export/tests/functional/Bigquery/SqlBuildTest.php
@@ -593,12 +593,12 @@ class SqlBuildTest extends BigqueryBaseTestCase
         yield 'typed' => [ // nothing is converted
             BigqueryImportOptions::USING_TYPES_USER,
             // phpcs:ignore
-            'UPDATE `import_export_test_schema`.`import_export_test_test` AS `dest` SET `col1` = `src`.`col1`, `col2` = `src`.`col2` FROM `import_export_test_schema`.`stagingTable` AS `src` WHERE `dest`.`col1` = `src`.`col1` '
+            'UPDATE `import_export_test_schema`.`import_export_test_test` AS `dest` SET `col1` = `src`.`col1`, `col2` = `src`.`col2` FROM `import_export_test_schema`.`stagingTable` AS `src` WHERE `dest`.`col1` = `src`.`col1`  AND (`dest`.`col1` IS DISTINCT FROM `src`.`col1` OR `dest`.`col2` IS DISTINCT FROM `src`.`col2`)'
         ];
         yield 'string' => [
             BigqueryImportOptions::USING_TYPES_STRING,
             // phpcs:ignore
-            'UPDATE `import_export_test_schema`.`import_export_test_test` AS `dest` SET `col1` = IF(`src`.`col1` = \'\', NULL, `src`.`col1`), `col2` = COALESCE(`src`.`col2`, \'\') FROM `import_export_test_schema`.`stagingTable` AS `src` WHERE `dest`.`col1` = COALESCE(`src`.`col1`, \'\') ',
+            'UPDATE `import_export_test_schema`.`import_export_test_test` AS `dest` SET `col1` = IF(`src`.`col1` = \'\', NULL, `src`.`col1`), `col2` = COALESCE(`src`.`col2`, \'\') FROM `import_export_test_schema`.`stagingTable` AS `src` WHERE `dest`.`col1` = COALESCE(`src`.`col1`, \'\')   AND (`dest`.`col1` IS DISTINCT FROM `src`.`col1` OR `dest`.`col2` IS DISTINCT FROM `src`.`col2`)',
         ];
     }
 

--- a/packages/php-db-import-export/tests/functional/Bigquery/SqlBuildTest.php
+++ b/packages/php-db-import-export/tests/functional/Bigquery/SqlBuildTest.php
@@ -503,7 +503,7 @@ class SqlBuildTest extends BigqueryBaseTestCase
         yield 'string' => [
             BigqueryImportOptions::USING_TYPES_STRING,
             // phpcs:ignore
-            'UPDATE `import_export_test_schema`.`import_export_test_test` AS `dest` SET `col1` = COALESCE(`src`.`col1`, \'\'), `col2` = COALESCE(`src`.`col2`, \'\') FROM `import_export_test_schema`.`stagingTable` AS `src` WHERE `dest`.`col1` = COALESCE(`src`.`col1`, \'\')  AND (`dest`.`col1` IS DISTINCT FROM `src`.`col1` OR `dest`.`col2` IS DISTINCT FROM `src`.`col2`)',
+            'UPDATE `import_export_test_schema`.`import_export_test_test` AS `dest` SET `col1` = COALESCE(`src`.`col1`, \'\'), `col2` = COALESCE(`src`.`col2`, \'\') FROM `import_export_test_schema`.`stagingTable` AS `src` WHERE `dest`.`col1` = COALESCE(`src`.`col1`, \'\')  AND (`dest`.`col1` != COALESCE(`src`.`col1`, \'\') OR `dest`.`col2` = COALESCE(`src`.`col2`, \'\'))',
         ];
     }
 
@@ -598,7 +598,7 @@ class SqlBuildTest extends BigqueryBaseTestCase
         yield 'string' => [
             BigqueryImportOptions::USING_TYPES_STRING,
             // phpcs:ignore
-            'UPDATE `import_export_test_schema`.`import_export_test_test` AS `dest` SET `col1` = IF(`src`.`col1` = \'\', NULL, `src`.`col1`), `col2` = COALESCE(`src`.`col2`, \'\') FROM `import_export_test_schema`.`stagingTable` AS `src` WHERE `dest`.`col1` = COALESCE(`src`.`col1`, \'\')   AND (`dest`.`col1` IS DISTINCT FROM `src`.`col1` OR `dest`.`col2` IS DISTINCT FROM `src`.`col2`)',
+            'UPDATE `import_export_test_schema`.`import_export_test_test` AS `dest` SET `col1` = IF(`src`.`col1` = \'\', NULL, `src`.`col1`), `col2` = COALESCE(`src`.`col2`, \'\') FROM `import_export_test_schema`.`stagingTable` AS `src` WHERE `dest`.`col1` = COALESCE(`src`.`col1`, \'\')   AND (`dest`.`col1` != COALESCE(`src`.`col1`, \'\') OR `dest`.`col2` != COALESCE(`src`.`col2`, \'\'))',
         ];
     }
 

--- a/packages/php-db-import-export/tests/functional/Bigquery/SqlBuildTest.php
+++ b/packages/php-db-import-export/tests/functional/Bigquery/SqlBuildTest.php
@@ -503,7 +503,7 @@ class SqlBuildTest extends BigqueryBaseTestCase
         yield 'string' => [
             BigqueryImportOptions::USING_TYPES_STRING,
             // phpcs:ignore
-            'UPDATE `import_export_test_schema`.`import_export_test_test` AS `dest` SET `col1` = COALESCE(`src`.`col1`, \'\'), `col2` = COALESCE(`src`.`col2`, \'\') FROM `import_export_test_schema`.`stagingTable` AS `src` WHERE `dest`.`col1` = COALESCE(`src`.`col1`, \'\')  AND (`dest`.`col1` != COALESCE(`src`.`col1`, \'\') OR `dest`.`col2` = COALESCE(`src`.`col2`, \'\'))',
+            'UPDATE `import_export_test_schema`.`import_export_test_test` AS `dest` SET `col1` = COALESCE(`src`.`col1`, \'\'), `col2` = COALESCE(`src`.`col2`, \'\') FROM `import_export_test_schema`.`stagingTable` AS `src` WHERE `dest`.`col1` = COALESCE(`src`.`col1`, \'\')  AND (`dest`.`col1` != COALESCE(`src`.`col1`, \'\') OR `dest`.`col2` != COALESCE(`src`.`col2`, \'\'))',
         ];
     }
 

--- a/packages/php-db-import-export/tests/functional/Bigquery/SqlBuildTest.php
+++ b/packages/php-db-import-export/tests/functional/Bigquery/SqlBuildTest.php
@@ -498,12 +498,12 @@ class SqlBuildTest extends BigqueryBaseTestCase
         yield 'typed' => [ // nothing is converted
             BigqueryImportOptions::USING_TYPES_USER,
             // phpcs:ignore
-            'UPDATE `import_export_test_schema`.`import_export_test_test` AS `dest` SET `col1` = `src`.`col1`, `col2` = `src`.`col2` FROM `import_export_test_schema`.`stagingTable` AS `src` WHERE `dest`.`col1` = `src`.`col1` '
+            'UPDATE `import_export_test_schema`.`import_export_test_test` AS `dest` SET `col1` = `src`.`col1`, `col2` = `src`.`col2` FROM `import_export_test_schema`.`stagingTable` AS `src` WHERE `dest`.`col1` = `src`.`col1`  AND (`dest`.`col1` IS DISTINCT FROM `src`.`col1` OR `dest`.`col2` IS DISTINCT FROM `src`.`col2`)'
         ];
         yield 'string' => [
             BigqueryImportOptions::USING_TYPES_STRING,
             // phpcs:ignore
-            'UPDATE `import_export_test_schema`.`import_export_test_test` AS `dest` SET `col1` = COALESCE(`src`.`col1`, \'\'), `col2` = COALESCE(`src`.`col2`, \'\') FROM `import_export_test_schema`.`stagingTable` AS `src` WHERE `dest`.`col1` = COALESCE(`src`.`col1`, \'\') ',
+            'UPDATE `import_export_test_schema`.`import_export_test_test` AS `dest` SET `col1` = COALESCE(`src`.`col1`, \'\'), `col2` = COALESCE(`src`.`col2`, \'\') FROM `import_export_test_schema`.`stagingTable` AS `src` WHERE `dest`.`col1` = COALESCE(`src`.`col1`, \'\')  AND (`dest`.`col1` IS DISTINCT FROM `src`.`col1` OR `dest`.`col2` IS DISTINCT FROM `src`.`col2`)',
         ];
     }
 

--- a/packages/php-db-import-export/tests/functional/Bigquery/SqlBuildTest.php
+++ b/packages/php-db-import-export/tests/functional/Bigquery/SqlBuildTest.php
@@ -598,7 +598,7 @@ class SqlBuildTest extends BigqueryBaseTestCase
         yield 'string' => [
             BigqueryImportOptions::USING_TYPES_STRING,
             // phpcs:ignore
-            'UPDATE `import_export_test_schema`.`import_export_test_test` AS `dest` SET `col1` = IF(`src`.`col1` = \'\', NULL, `src`.`col1`), `col2` = COALESCE(`src`.`col2`, \'\') FROM `import_export_test_schema`.`stagingTable` AS `src` WHERE `dest`.`col1` = COALESCE(`src`.`col1`, \'\')   AND (`dest`.`col1` != COALESCE(`src`.`col1`, \'\') OR `dest`.`col2` != COALESCE(`src`.`col2`, \'\'))',
+            'UPDATE `import_export_test_schema`.`import_export_test_test` AS `dest` SET `col1` = IF(`src`.`col1` = \'\', NULL, `src`.`col1`), `col2` = COALESCE(`src`.`col2`, \'\') FROM `import_export_test_schema`.`stagingTable` AS `src` WHERE `dest`.`col1` = COALESCE(`src`.`col1`, \'\')  AND (`dest`.`col1` != COALESCE(`src`.`col1`, \'\') OR `dest`.`col2` != COALESCE(`src`.`col2`, \'\'))',
         ];
     }
 

--- a/packages/php-db-import-export/tests/functional/Bigquery/SqlBuildTest.php
+++ b/packages/php-db-import-export/tests/functional/Bigquery/SqlBuildTest.php
@@ -708,7 +708,7 @@ class SqlBuildTest extends BigqueryBaseTestCase
         yield 'string' => [
             BigqueryImportOptions::USING_TYPES_STRING,
             // phpcs:ignore
-            'UPDATE `import_export_test_schema`.`import_export_test_test` AS `dest` SET `col1` = IF(`src`.`col1` = \'\', NULL, `src`.`col1`), `col2` = COALESCE(`src`.`col2`, \'\'), `_timestamp` = \'2020-01-01 01:01:01\' FROM `import_export_test_schema`.`stagingTable` AS `src` WHERE `dest`.`col1` = COALESCE(`src`.`col1`, \'\')  AND (`dest`.`col1` IS DISTINCT FROM `src`.`col1` OR `dest`.`col2` IS DISTINCT FROM `src`.`col2`)',
+            'UPDATE `import_export_test_schema`.`import_export_test_test` AS `dest` SET `col1` = IF(`src`.`col1` = \'\', NULL, `src`.`col1`), `col2` = COALESCE(`src`.`col2`, \'\'), `_timestamp` = \'2020-01-01 01:01:01\' FROM `import_export_test_schema`.`stagingTable` AS `src` WHERE `dest`.`col1` = COALESCE(`src`.`col1`, \'\')  AND (`dest`.`col1` != COALESCE(`src`.`col1`, \'\') OR `dest`.`col2` != COALESCE(`src`.`col2`, \'\'))',
         ];
     }
 

--- a/packages/php-db-import-export/tests/functional/Bigquery/ToFinal/IncrementalImportTest.php
+++ b/packages/php-db-import-export/tests/functional/Bigquery/ToFinal/IncrementalImportTest.php
@@ -286,75 +286,7 @@ class IncrementalImportTest extends BigqueryBaseTestCase
                     'name'=> 'test3',
                     'price'=> 300,
                     'isDeleted'=> 0,
-                    '_timestamp'=> '2022-02-02 00:00:00', // no change timestamp updated
-                ],
-                [
-                    'id'=> 4,
-                    'name'=> 'test4',
-                    'price'=> 400,
-                    'isDeleted'=> 0,
-                    '_timestamp'=> '2022-02-02 00:00:00',
-                ],
-            ],
-        ];
-
-        yield 'import typed table, timestamp update onchange feature: `new-native-types`' => [
-            'features' => ['new-native-types'],
-            'expectedContent' => [
-                [
-                    'id'=> 1,
-                    'name'=> 'change',
-                    'price'=> 100,
-                    'isDeleted'=> 0,
-                    '_timestamp'=> '2022-02-02 00:00:00',
-                ],
-                [
-                    'id'=> 2,
-                    'name'=> 'test2',
-                    'price'=> 200,
-                    'isDeleted'=> 0,
-                    '_timestamp'=> '2021-01-01 00:00:00',
-                ],
-                [
-                    'id'=> 3,
-                    'name'=> 'test3',
-                    'price'=> 300,
-                    'isDeleted'=> 0,
-                    '_timestamp'=> '2021-01-01 00:00:00', // no change no timestamp update
-                ],
-                [
-                    'id'=> 4,
-                    'name'=> 'test4',
-                    'price'=> 400,
-                    'isDeleted'=> 0,
-                    '_timestamp'=> '2022-02-02 00:00:00',
-                ],
-            ],
-        ];
-
-        yield 'import typed table, timestamp update onchange feature: `native-types_timestamp-bc`' => [
-            'features' => ['native-types_timestamp-bc'],
-            'expectedContent' => [
-                [
-                    'id'=> 1,
-                    'name'=> 'change',
-                    'price'=> 100,
-                    'isDeleted'=> 0,
-                    '_timestamp'=> '2022-02-02 00:00:00',
-                ],
-                [
-                    'id'=> 2,
-                    'name'=> 'test2',
-                    'price'=> 200,
-                    'isDeleted'=> 0,
-                    '_timestamp'=> '2021-01-01 00:00:00',
-                ],
-                [
-                    'id'=> 3,
-                    'name'=> 'test3',
-                    'price'=> 300,
-                    'isDeleted'=> 0,
-                    '_timestamp'=> '2021-01-01 00:00:00', // no change no timestamp update
+                    '_timestamp'=> '2021-01-01 00:00:00', // no change, no timestamp update
                 ],
                 [
                     'id'=> 4,
@@ -381,20 +313,13 @@ class IncrementalImportTest extends BigqueryBaseTestCase
               `name` STRING(50),
               `price` DECIMAL,
               `isDeleted` INT64,
-              `_timestamp` TIMESTAMP
+              `_timestamp` TIMESTAMP,
+               PRIMARY KEY(id) NOT ENFORCED
            )',
             BigqueryQuote::quoteSingleIdentifier($this->getDestinationDbName()),
             BigqueryQuote::quoteSingleIdentifier(self::TABLE_TRANSLATIONS),
         )));
-        $this->bqClient->dataset($this->getDestinationDbName())->table(self::TABLE_TRANSLATIONS)->update(
-            [
-                'tableConstraints' => [
-                    'primaryKey' => [
-                        'columns' => 'id',
-                    ],
-                ],
-            ],
-        );
+
         $this->initTable(self::TABLE_TRANSLATIONS, $this->getSourceDbName());
         $destination = (new BigqueryTableReflection(
             $this->bqClient,

--- a/packages/php-db-import-export/tests/functional/Bigquery/ToFinal/IncrementalImportTest.php
+++ b/packages/php-db-import-export/tests/functional/Bigquery/ToFinal/IncrementalImportTest.php
@@ -313,13 +313,20 @@ class IncrementalImportTest extends BigqueryBaseTestCase
               `name` STRING(50),
               `price` DECIMAL,
               `isDeleted` INT64,
-              `_timestamp` TIMESTAMP,
-               PRIMARY KEY(id) NOT ENFORCED
+              `_timestamp` TIMESTAMP
            )',
             BigqueryQuote::quoteSingleIdentifier($this->getDestinationDbName()),
             BigqueryQuote::quoteSingleIdentifier(self::TABLE_TRANSLATIONS),
         )));
-
+        $this->bqClient->dataset($this->getDestinationDbName())->table(self::TABLE_TRANSLATIONS)->update(
+            [
+                'tableConstraints' => [
+                    'primaryKey' => [
+                        'columns' => 'id',
+                    ],
+                ],
+            ],
+        );
         $this->initTable(self::TABLE_TRANSLATIONS, $this->getSourceDbName());
         $destination = (new BigqueryTableReflection(
             $this->bqClient,

--- a/packages/php-db-import-export/tests/functional/Snowflake/SnowflakeBaseTestCase.php
+++ b/packages/php-db-import-export/tests/functional/Snowflake/SnowflakeBaseTestCase.php
@@ -8,10 +8,12 @@ use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Logging\Middleware;
 use Exception;
+use Keboola\Datatype\Definition\Snowflake;
 use Keboola\Db\ImportExport\Backend\Snowflake\SnowflakeImportOptions;
 use Keboola\Db\ImportExport\Backend\ToStageImporterInterface;
 use Keboola\Db\ImportExport\ImportOptions;
 use Keboola\Db\ImportExport\Storage\SourceInterface;
+use Keboola\TableBackendUtils\Column\Snowflake\SnowflakeColumn;
 use Keboola\TableBackendUtils\Connection\Snowflake\SnowflakeConnectionFactory;
 use Keboola\TableBackendUtils\Escaping\Snowflake\SnowflakeQuote;
 use Keboola\TableBackendUtils\Table\Snowflake\SnowflakeTableDefinition;
@@ -479,6 +481,22 @@ class SnowflakeBaseTestCase extends ImportExportBaseTest
             useTimestamp: true,
             numberOfIgnoredLines: $skipLines,
             ignoreColumns: [ToStageImporterInterface::TIMESTAMP_COLUMN_NAME],
+        );
+    }
+
+    protected function createNullableGenericColumn(string $columnName): SnowflakeColumn
+    {
+        $definition = new Snowflake(
+            Snowflake::TYPE_VARCHAR,
+            [
+                'length' => '4000', // should be changed to max in future
+                'nullable' => true,
+            ],
+        );
+
+        return new SnowflakeColumn(
+            $columnName,
+            $definition,
         );
     }
 }

--- a/packages/php-db-import-export/tests/functional/Snowflake/ToFinal/IncrementalImportTest.php
+++ b/packages/php-db-import-export/tests/functional/Snowflake/ToFinal/IncrementalImportTest.php
@@ -436,8 +436,7 @@ SELECT 2,
 
     public function incrementalImportTimestampBehavior(): Generator
     {
-        yield 'import typed table, timestamp update always `no feature`' => [
-            'features' => [],
+        yield 'import typed table, timestamp update onchange`' => [
             'expectedContent' => [
                 [
                     'id' => 1,
@@ -458,75 +457,7 @@ SELECT 2,
                     'name' => 'test3',
                     'price' => 300,
                     'isDeleted' => 0,
-                    '_timestamp' => '2022-02-02 00:00:00', // no change timestamp updated
-                ],
-                [
-                    'id' => 4,
-                    'name' => 'test4',
-                    'price' => 400,
-                    'isDeleted' => 0,
-                    '_timestamp' => '2022-02-02 00:00:00',
-                ],
-            ],
-        ];
-
-        yield 'import typed table, timestamp update onchange feature: `new-native-types`' => [
-            'features' => ['new-native-types'],
-            'expectedContent' => [
-                [
-                    'id' => 1,
-                    'name' => 'change',
-                    'price' => 100,
-                    'isDeleted' => 0,
-                    '_timestamp' => '2022-02-02 00:00:00',
-                ],
-                [
-                    'id' => 2,
-                    'name' => 'test2',
-                    'price' => 200,
-                    'isDeleted' => 0,
                     '_timestamp' => '2021-01-01 00:00:00',
-                ],
-                [
-                    'id' => 3,
-                    'name' => 'test3',
-                    'price' => 300,
-                    'isDeleted' => 0,
-                    '_timestamp' => '2021-01-01 00:00:00', // no change no timestamp update
-                ],
-                [
-                    'id' => 4,
-                    'name' => 'test4',
-                    'price' => 400,
-                    'isDeleted' => 0,
-                    '_timestamp' => '2022-02-02 00:00:00',
-                ],
-            ],
-        ];
-
-        yield 'import typed table, timestamp update onchange feature: `native-types_timestamp-bc`' => [
-            'features' => ['native-types_timestamp-bc'],
-            'expectedContent' => [
-                [
-                    'id' => 1,
-                    'name' => 'change',
-                    'price' => 100,
-                    'isDeleted' => 0,
-                    '_timestamp' => '2022-02-02 00:00:00',
-                ],
-                [
-                    'id' => 2,
-                    'name' => 'test2',
-                    'price' => 200,
-                    'isDeleted' => 0,
-                    '_timestamp' => '2021-01-01 00:00:00',
-                ],
-                [
-                    'id' => 3,
-                    'name' => 'test3',
-                    'price' => 300,
-                    'isDeleted' => 0,
-                    '_timestamp' => '2021-01-01 00:00:00', // no change no timestamp update
                 ],
                 [
                     'id' => 4,
@@ -541,10 +472,9 @@ SELECT 2,
 
     /**
      * @dataProvider incrementalImportTimestampBehavior
-     * @param string[] $features
      * @param array<mixed> $expectedContent
      */
-    public function testImportTimestampBehavior(array $features, array $expectedContent): void
+    public function testImportTimestampBehavior(array $expectedContent): void
     {
         $this->connection->executeQuery(sprintf(
             'CREATE TABLE %s.%s (
@@ -610,7 +540,6 @@ SELECT 2,
                 isIncremental: true,
                 useTimestamp: true,
                 nullManipulation: SnowflakeImportOptions::NULL_MANIPULATION_SKIP,
-                features: $features,
             ),
             $state,
         );

--- a/packages/php-db-import-export/tests/functional/Snowflake/ToFinal/SqlBuilderTest.php
+++ b/packages/php-db-import-export/tests/functional/Snowflake/ToFinal/SqlBuilderTest.php
@@ -767,22 +767,6 @@ EOD,
         return $tableDefinition;
     }
 
-    private function createNullableGenericColumn(string $columnName): SnowflakeColumn
-    {
-        $definition = new Snowflake(
-            Snowflake::TYPE_VARCHAR,
-            [
-                'length' => '4000', // should be changed to max in future
-                'nullable' => true,
-            ],
-        );
-
-        return new SnowflakeColumn(
-            $columnName,
-            $definition,
-        );
-    }
-
     public function testGetInsertAllIntoTargetTableCommandConvertToNull(): void
     {
         $this->createTestSchema();

--- a/packages/php-db-import-export/tests/functional/Snowflake/ToFinal/SqlBuilderTest.php
+++ b/packages/php-db-import-export/tests/functional/Snowflake/ToFinal/SqlBuilderTest.php
@@ -1538,20 +1538,8 @@ EOD,
         yield 'default' => [
             'default',
             // phpcs:ignore
-            'UPDATE "import_export_test_schema"."import_export_test_test" AS "dest" SET "col1" = "src"."col1", "col2" = "src"."col2", "_timestamp" = \'2020-01-01 01:01:01\' FROM "import_export_test_schema"."__temp_stagingTable" AS "src" WHERE "dest"."col1" = "src"."col1" ',
+            'UPDATE "import_export_test_schema"."import_export_test_test" AS "dest" SET "col1" = "src"."col1", "col2" = "src"."col2", "_timestamp" = \'2020-01-01 01:01:01\' FROM "import_export_test_schema"."__temp_stagingTable" AS "src" WHERE "dest"."col1" = "src"."col1"  AND ("dest"."col1" IS DISTINCT FROM "src"."col1" OR "dest"."col2" IS DISTINCT FROM "src"."col2")',
             true,
-        ];
-        yield 'new-native-types' => [
-            'new-native-types',
-            // phpcs:ignore
-            'UPDATE "import_export_test_schema"."import_export_test_test" AS "dest" SET "col1" = "src"."col1", "col2" = "src"."col2", "_timestamp" = \'2020-01-01 01:01:01\' FROM "import_export_test_schema"."__temp_stagingTable" AS "src" WHERE "dest"."col1" = "src"."col1"  AND ("dest"."col1" IS DISTINCT FROM "src"."col1" OR "dest"."col2" IS DISTINCT FROM "src"."col2")',
-            false,
-        ];
-        yield 'native-types_timestamp-bc' => [
-            'native-types_timestamp-bc',
-            // phpcs:ignore
-            'UPDATE "import_export_test_schema"."import_export_test_test" AS "dest" SET "col1" = "src"."col1", "col2" = "src"."col2", "_timestamp" = \'2020-01-01 01:01:01\' FROM "import_export_test_schema"."__temp_stagingTable" AS "src" WHERE "dest"."col1" = "src"."col1"  AND ("dest"."col1" IS DISTINCT FROM "src"."col1" OR "dest"."col2" IS DISTINCT FROM "src"."col2")',
-            false,
         ];
     }
 

--- a/packages/php-db-import-export/tests/functional/Snowflake/ToFinal/SqlBuilderTest.php
+++ b/packages/php-db-import-export/tests/functional/Snowflake/ToFinal/SqlBuilderTest.php
@@ -1044,7 +1044,7 @@ EOD,
         );
         self::assertEquals(
         // phpcs:ignore
-            'UPDATE "import_export_test_schema"."import_export_test_test" AS "dest" SET "col1" = "src"."col1", "col2" = "src"."col2" FROM "import_export_test_schema"."__temp_stagingTable" AS "src" WHERE "dest"."col1" = "src"."col1" ',
+            'UPDATE "import_export_test_schema"."import_export_test_test" AS "dest" SET "col1" = "src"."col1", "col2" = "src"."col2" FROM "import_export_test_schema"."__temp_stagingTable" AS "src" WHERE "dest"."col1" = "src"."col1"  AND ("dest"."col1" IS DISTINCT FROM "src"."col1" OR "dest"."col2" IS DISTINCT FROM "src"."col2")',
             $sql,
         );
         $this->connection->executeStatement($sql);

--- a/packages/php-db-import-export/tests/functional/Snowflake/ToFinal/SqlBuilderTest.php
+++ b/packages/php-db-import-export/tests/functional/Snowflake/ToFinal/SqlBuilderTest.php
@@ -1533,10 +1533,9 @@ EOD,
     public function nullManipulationWithTimestampFeatures(): Generator
     {
         yield 'default' => [
-            'default',
             // phpcs:ignore
             'UPDATE "import_export_test_schema"."import_export_test_test" AS "dest" SET "col1" = "src"."col1", "col2" = "src"."col2", "_timestamp" = \'2020-01-01 01:01:01\' FROM "import_export_test_schema"."__temp_stagingTable" AS "src" WHERE "dest"."col1" = "src"."col1"  AND ("dest"."col1" IS DISTINCT FROM "src"."col1" OR "dest"."col2" IS DISTINCT FROM "src"."col2")',
-            true,
+            false,
         ];
     }
 
@@ -1544,7 +1543,6 @@ EOD,
      * @dataProvider nullManipulationWithTimestampFeatures
      */
     public function testGetUpdateWithPkCommandNullManipulationWithTimestampFeatures(
-        string $feature,
         string $expectedSQL,
         bool $expectedTimestampChange,
     ): void {
@@ -1628,7 +1626,7 @@ EOD,
             requireSameTables: SnowflakeImportOptions::SAME_TABLES_REQUIRED,
             nullManipulation: SnowflakeImportOptions::NULL_MANIPULATION_SKIP,
             ignoreColumns: [ToStageImporterInterface::TIMESTAMP_COLUMN_NAME],
-            features: [$feature],
+            features: [],
         );
         $sql = $this->getBuilder()->getUpdateWithPkCommand(
             $fakeStage,


### PR DESCRIPTION
Jira: CT-1424
Connection PR: https://github.com/keboola/connection/pull/5347
SAPI PR: -

---

I have dropped the dependency on `native-types_timestamp-bc` feature because it should be by default these days
-> I removed `compareAllColumnsInNativeTable` -> SQL builder has been changed so now all INC load does comparing all the columns -> all the tests had to be fixed... kill me now

tag in connection was successful https://dev.azure.com/keboola-dev/Connection%20build/_build/results?buildId=51963&view=results