### PR TITLE
Increase maximum VARCHAR size in Snowflake to 128MB

### DIFF
--- a/packages/php-datatypes/src/Definition/Snowflake.php
+++ b/packages/php-datatypes/src/Definition/Snowflake.php
@@ -106,6 +106,7 @@ class Snowflake extends Common
         self::TYPE_GEOMETRY,
         self::TYPE_VECTOR,
     ];
+    public const DEFAULT_VARCHAR_LENGTH = 16777216;
     public const MAX_VARCHAR_LENGTH = 134217728;
     public const MAX_VARBINARY_LENGTH = 8388608;
 

--- a/packages/php-datatypes/src/Definition/Snowflake.php
+++ b/packages/php-datatypes/src/Definition/Snowflake.php
@@ -106,7 +106,7 @@ class Snowflake extends Common
         self::TYPE_GEOMETRY,
         self::TYPE_VECTOR,
     ];
-    public const MAX_VARCHAR_LENGTH = 16777216;
+    public const MAX_VARCHAR_LENGTH = 134217728;
     public const MAX_VARBINARY_LENGTH = 8388608;
 
     /**

--- a/packages/php-datatypes/tests/SnowflakeDatatypeTest.php
+++ b/packages/php-datatypes/tests/SnowflakeDatatypeTest.php
@@ -216,10 +216,10 @@ class SnowflakeDatatypeTest extends BaseDatatypeTestCase
         new Snowflake('STRING');
         new Snowflake('STRING', ['length' => '']);
         new Snowflake('STRING', ['length' => '1']);
-        new Snowflake('STRING', ['length' => '16777216']);
+        new Snowflake('STRING', ['length' => '134217728']);
         new Snowflake('STRING', [
             'length' => [
-                'character_maximum' => '16777216',
+                'character_maximum' => '134217728',
             ],
         ]);
         new Snowflake('STRING', [
@@ -444,7 +444,7 @@ class SnowflakeDatatypeTest extends BaseDatatypeTestCase
         return [
             ['a'],
             ['0'],
-            ['16777217'],
+            ['134217729'],
             ['-1'],
         ];
     }

--- a/packages/php-db-import-export/src/Backend/Snowflake/ToStage/StageTableDefinitionFactory.php
+++ b/packages/php-db-import-export/src/Backend/Snowflake/ToStage/StageTableDefinitionFactory.php
@@ -87,7 +87,7 @@ final class StageTableDefinitionFactory
             new Snowflake(
                 Snowflake::TYPE_VARCHAR,
                 [
-                    'length' => (string) Snowflake::MAX_VARCHAR_LENGTH,
+                    'length' => (string) Snowflake::DEFAULT_VARCHAR_LENGTH,
                     'nullable' => true, // set all columns to be nullable
                 ],
             ),


### PR DESCRIPTION
https://keboola.atlassian.net/browse/SUPPORT-11491

Increase maximum VARCHAR size in Snowflake to 128MB, according to 2025_02 Bundle.
https://docs.snowflake.com/en/release-notes/bcr-bundles/2025_02/bcr-1942

CSAS has the bundle already enabled and they're trying to create a VARCHAR column with increased size, but it's failing on validation.


