### PR TITLE
PAT-261 INC_21878 use result scan

### DIFF
--- a/packages/php-db-import-export/src/Backend/Snowflake/Export/AbsExportAdapter.php
+++ b/packages/php-db-import-export/src/Backend/Snowflake/Export/AbsExportAdapter.php
@@ -66,8 +66,10 @@ DETAILED_OUTPUT = TRUE',
             Exporter::DEFAULT_SLICE_SIZE,
         );
 
+        $this->connection->executeQuery($sql, $source->getQueryBindings());
+
         /** @var array<array{FILE_NAME: string, FILE_SIZE: string, ROW_COUNT: string}> $unloadedFiles */
-        $unloadedFiles = $this->connection->fetchAllAssociative($sql, $source->getQueryBindings());
+        $unloadedFiles = $this->connection->fetchAllAssociative('select * from table(result_scan(last_query_id()));');
 
         if ($exportOptions->generateManifest()) {
             (new Storage\ABS\ManifestGenerator\AbsSlicedManifestFromUnloadQueryResultGenerator(

--- a/packages/php-db-import-export/src/Backend/Snowflake/Export/GcsExportAdapter.php
+++ b/packages/php-db-import-export/src/Backend/Snowflake/Export/GcsExportAdapter.php
@@ -68,7 +68,6 @@ DETAILED_OUTPUT = TRUE',
             Exporter::DEFAULT_SLICE_SIZE,
         );
 
-
         $this->connection->executeQuery($sql, $source->getQueryBindings());
 
         /** @var array<array{FILE_NAME: string, FILE_SIZE: string, ROW_COUNT: string}> $unloadedFiles */

--- a/packages/php-db-import-export/src/Backend/Snowflake/Export/GcsExportAdapter.php
+++ b/packages/php-db-import-export/src/Backend/Snowflake/Export/GcsExportAdapter.php
@@ -68,8 +68,11 @@ DETAILED_OUTPUT = TRUE',
             Exporter::DEFAULT_SLICE_SIZE,
         );
 
+
+        $this->connection->executeQuery($sql, $source->getQueryBindings());
+
         /** @var array<array{FILE_NAME: string, FILE_SIZE: string, ROW_COUNT: string}> $unloadedFiles */
-        $unloadedFiles = $this->connection->fetchAllAssociative($sql, $source->getQueryBindings());
+        $unloadedFiles = $this->connection->fetchAllAssociative('select * from table(result_scan(last_query_id()));');
 
         if ($exportOptions->generateManifest()) {
             (new Storage\GCS\ManifestGenerator\GcsSlicedManifestFromUnloadQueryResultGenerator(

--- a/packages/php-db-import-export/src/Backend/Snowflake/Export/S3ExportAdapter.php
+++ b/packages/php-db-import-export/src/Backend/Snowflake/Export/S3ExportAdapter.php
@@ -79,8 +79,10 @@ EOT,
             Exporter::DEFAULT_SLICE_SIZE,
         );
 
+        $this->connection->executeQuery($sql, $source->getQueryBindings());
+
         /** @var array<array{FILE_NAME: string, FILE_SIZE: string, ROW_COUNT: string}> $unloadedFiles */
-        $unloadedFiles = $this->connection->fetchAllAssociative($sql, $source->getQueryBindings());
+        $unloadedFiles = $this->connection->fetchAllAssociative('select * from table(result_scan(last_query_id()));');
 
         if ($exportOptions->generateManifest()) {
             (new Storage\S3\ManifestGenerator\S3SlicedManifestFromUnloadQueryResultGenerator($destination->getClient()))

--- a/packages/php-db-import-export/src/Storage/ABS/SnowflakeExportAdapter.php
+++ b/packages/php-db-import-export/src/Storage/ABS/SnowflakeExportAdapter.php
@@ -62,7 +62,10 @@ DETAILED_OUTPUT = TRUE',
             $exportOptions->isCompressed() ? "COMPRESSION='GZIP'" : "COMPRESSION='NONE'",
         );
 
-        $unloadedFiles = $this->connection->fetchAll($sql, $source->getQueryBindings());
+        $this->connection->query($sql, $source->getQueryBindings());
+
+        /** @var array<array{FILE_NAME: string, FILE_SIZE: string, ROW_COUNT: string}> $unloadedFiles */
+        $unloadedFiles = $this->connection->fetchAll('select * from table(result_scan(last_query_id()));');
 
         if ($exportOptions->generateManifest()) {
             (new Storage\ABS\ManifestGenerator\AbsSlicedManifestFromUnloadQueryResultGenerator(

--- a/packages/php-db-import-export/src/Storage/GCS/SnowflakeExportAdapter.php
+++ b/packages/php-db-import-export/src/Storage/GCS/SnowflakeExportAdapter.php
@@ -63,8 +63,10 @@ DETAILED_OUTPUT = TRUE',
             $destination->getStorageIntegrationName(),
             $exportOptions->isCompressed() ? "COMPRESSION='GZIP'" : "COMPRESSION='NONE'",
         );
+        $this->connection->query($sql, $source->getQueryBindings());
 
-        $unloadedFiles = $this->connection->fetchAll($sql, $source->getQueryBindings());
+        /** @var array<array{FILE_NAME: string, FILE_SIZE: string, ROW_COUNT: string}> $unloadedFiles */
+        $unloadedFiles = $this->connection->fetchAll('select * from table(result_scan(last_query_id()));');
 
         if ($exportOptions->generateManifest()) {
             (new Storage\GCS\ManifestGenerator\GcsSlicedManifestFromUnloadQueryResultGenerator(

--- a/packages/php-db-import-export/src/Storage/S3/SnowflakeExportAdapter.php
+++ b/packages/php-db-import-export/src/Storage/S3/SnowflakeExportAdapter.php
@@ -75,7 +75,10 @@ EOT,
             $exportOptions->isCompressed() ? "COMPRESSION='GZIP'" : "COMPRESSION='NONE'",
         );
 
-        $unloadedFiles = $this->connection->fetchAll($sql, $source->getQueryBindings());
+        $this->connection->query($sql, $source->getQueryBindings());
+
+        /** @var array<array{FILE_NAME: string, FILE_SIZE: string, ROW_COUNT: string}> $unloadedFiles */
+        $unloadedFiles = $this->connection->fetchAll('select * from table(result_scan(last_query_id()));');
 
         if ($exportOptions->generateManifest()) {
             (new Storage\S3\ManifestGenerator\S3SlicedManifestFromUnloadQueryResultGenerator($destination->getClient()))

--- a/packages/php-db-import-export/tests/unit/Backend/Snowflake/Exporter/AbsExportAdapterTest.php
+++ b/packages/php-db-import-export/tests/unit/Backend/Snowflake/Exporter/AbsExportAdapterTest.php
@@ -50,7 +50,8 @@ EOT
             [],
         );
 
-        $conn->expects(self::once())->method('fetchAllAssociative')->with('select * from table(result_scan(last_query_id()));')
+        $conn->expects(self::once())->method('fetchAllAssociative')
+            ->with('select * from table(result_scan(last_query_id()));')
             ->willReturn($expectedCopyResult);
 
         $source = new Storage\Snowflake\Table('schema', 'table');
@@ -104,7 +105,8 @@ EOT
             [],
         );
 
-        $conn->expects(self::once())->method('fetchAllAssociative')->with('select * from table(result_scan(last_query_id()));')
+        $conn->expects(self::once())->method('fetchAllAssociative')
+            ->with('select * from table(result_scan(last_query_id()));')
             ->willReturn($expectedCopyResult);
 
         $source = new Storage\Snowflake\Table('schema', 'table');
@@ -158,7 +160,8 @@ EOT
             [],
         );
 
-        $conn->expects(self::once())->method('fetchAllAssociative')->with('select * from table(result_scan(last_query_id()));')
+        $conn->expects(self::once())->method('fetchAllAssociative')
+            ->with('select * from table(result_scan(last_query_id()));')
             ->willReturn($expectedCopyResult);
 
         $source = new Storage\Snowflake\SelectSource('SELECT * FROM "schema"."table"');

--- a/packages/php-db-import-export/tests/unit/Backend/Snowflake/Exporter/AbsExportAdapterTest.php
+++ b/packages/php-db-import-export/tests/unit/Backend/Snowflake/Exporter/AbsExportAdapterTest.php
@@ -30,7 +30,7 @@ class AbsExportAdapterTest extends BaseTestCase
 
         /** @var Connection|MockObject $conn */
         $conn = $this->createMock(Connection::class);
-        $conn->expects(self::once())->method('fetchAllAssociative')->with(
+        $conn->expects(self::once())->method('executeQuery')->with(
             <<<EOT
 COPY INTO 'containerUrl' 
 FROM (SELECT * FROM "schema"."table")
@@ -48,7 +48,10 @@ DETAILED_OUTPUT = TRUE
 EOT
             ,
             [],
-        )->willReturn($expectedCopyResult);
+        );
+
+        $conn->expects(self::once())->method('fetchAllAssociative')->with('select * from table(result_scan(last_query_id()));')
+            ->willReturn($expectedCopyResult);
 
         $source = new Storage\Snowflake\Table('schema', 'table');
         $options = new ExportOptions(false, ExportOptions::MANIFEST_SKIP);
@@ -81,7 +84,7 @@ EOT
 
         /** @var Connection|MockObject $conn */
         $conn = $this->createMock(Connection::class);
-        $conn->expects(self::once())->method('fetchAllAssociative')->with(
+        $conn->expects(self::once())->method('executeQuery')->with(
             <<<EOT
 COPY INTO 'containerUrl' 
 FROM (SELECT * FROM "schema"."table")
@@ -99,7 +102,10 @@ DETAILED_OUTPUT = TRUE
 EOT
             ,
             [],
-        )->willReturn($expectedCopyResult);
+        );
+
+        $conn->expects(self::once())->method('fetchAllAssociative')->with('select * from table(result_scan(last_query_id()));')
+            ->willReturn($expectedCopyResult);
 
         $source = new Storage\Snowflake\Table('schema', 'table');
         $options = new ExportOptions(true, ExportOptions::MANIFEST_SKIP);
@@ -132,7 +138,7 @@ EOT
 
         /** @var Connection|MockObject $conn */
         $conn = $this->createMock(Connection::class);
-        $conn->expects(self::once())->method('fetchAllAssociative')->with(
+        $conn->expects(self::once())->method('executeQuery')->with(
             <<<EOT
 COPY INTO 'containerUrl' 
 FROM (SELECT * FROM "schema"."table")
@@ -150,7 +156,10 @@ DETAILED_OUTPUT = TRUE
 EOT
             ,
             [],
-        )->willReturn($expectedCopyResult);
+        );
+
+        $conn->expects(self::once())->method('fetchAllAssociative')->with('select * from table(result_scan(last_query_id()));')
+            ->willReturn($expectedCopyResult);
 
         $source = new Storage\Snowflake\SelectSource('SELECT * FROM "schema"."table"');
         $options = new ExportOptions(false, ExportOptions::MANIFEST_SKIP);

--- a/packages/php-db-import-export/tests/unit/Backend/Snowflake/Exporter/GcsExportAdapterTest.php
+++ b/packages/php-db-import-export/tests/unit/Backend/Snowflake/Exporter/GcsExportAdapterTest.php
@@ -23,7 +23,7 @@ class GcsExportAdapterTest extends BaseTestCase
 
         /** @var Connection|MockObject $conn */
         $conn = $this->createMock(Connection::class);
-        $conn->expects(self::once())->method('fetchAllAssociative')->with(
+        $conn->expects(self::once())->method('executeQuery')->with(
             <<<EOT
 COPY INTO 'bucket/xxx/path'
 FROM (SELECT * FROM "schema"."table")
@@ -41,7 +41,10 @@ DETAILED_OUTPUT = TRUE
 EOT
             ,
             [],
-        )->willReturn([]);
+        );
+
+        $conn->expects(self::once())->method('fetchAllAssociative')->with('select * from table(result_scan(last_query_id()));')
+            ->willReturn([]);
 
         $source = new Storage\Snowflake\Table('schema', 'table');
         $options = new ExportOptions(false, ExportOptions::MANIFEST_SKIP);
@@ -67,7 +70,7 @@ EOT
 
         /** @var Connection|MockObject $conn */
         $conn = $this->createMock(Connection::class);
-        $conn->expects(self::once())->method('fetchAllAssociative')->with(
+        $conn->expects(self::once())->method('executeQuery')->with(
             <<<EOT
 COPY INTO 'bucket/test/file'
 FROM (SELECT * FROM "schema"."table")
@@ -85,7 +88,10 @@ DETAILED_OUTPUT = TRUE
 EOT
             ,
             [],
-        )->willReturn([]);
+        );
+
+        $conn->expects(self::once())->method('fetchAllAssociative')->with('select * from table(result_scan(last_query_id()));')
+            ->willReturn([]);
 
         $source = new Storage\Snowflake\Table('schema', 'table');
         $options = new ExportOptions(true, ExportOptions::MANIFEST_SKIP);
@@ -111,7 +117,7 @@ EOT
 
         /** @var Connection|MockObject $conn */
         $conn = $this->createMock(Connection::class);
-        $conn->expects(self::once())->method('fetchAllAssociative')->with(
+        $conn->expects(self::once())->method('executeQuery')->with(
             <<<EOT
 COPY INTO 'bucket/test/file'
 FROM (SELECT * FROM "schema"."tableName")
@@ -129,7 +135,10 @@ DETAILED_OUTPUT = TRUE
 EOT
             ,
             [],
-        )->willReturn([]);
+        );
+
+        $conn->expects(self::once())->method('fetchAllAssociative')->with('select * from table(result_scan(last_query_id()));')
+            ->willReturn([]);
 
         $source = new Storage\Snowflake\SelectSource('SELECT * FROM "schema"."tableName"');
         $options = new ExportOptions(false, ExportOptions::MANIFEST_SKIP);

--- a/packages/php-db-import-export/tests/unit/Backend/Snowflake/Exporter/GcsExportAdapterTest.php
+++ b/packages/php-db-import-export/tests/unit/Backend/Snowflake/Exporter/GcsExportAdapterTest.php
@@ -43,7 +43,8 @@ EOT
             [],
         );
 
-        $conn->expects(self::once())->method('fetchAllAssociative')->with('select * from table(result_scan(last_query_id()));')
+        $conn->expects(self::once())->method('fetchAllAssociative')
+            ->with('select * from table(result_scan(last_query_id()));')
             ->willReturn([]);
 
         $source = new Storage\Snowflake\Table('schema', 'table');
@@ -90,7 +91,8 @@ EOT
             [],
         );
 
-        $conn->expects(self::once())->method('fetchAllAssociative')->with('select * from table(result_scan(last_query_id()));')
+        $conn->expects(self::once())->method('fetchAllAssociative')
+            ->with('select * from table(result_scan(last_query_id()));')
             ->willReturn([]);
 
         $source = new Storage\Snowflake\Table('schema', 'table');
@@ -137,7 +139,8 @@ EOT
             [],
         );
 
-        $conn->expects(self::once())->method('fetchAllAssociative')->with('select * from table(result_scan(last_query_id()));')
+        $conn->expects(self::once())->method('fetchAllAssociative')
+            ->with('select * from table(result_scan(last_query_id()));')
             ->willReturn([]);
 
         $source = new Storage\Snowflake\SelectSource('SELECT * FROM "schema"."tableName"');

--- a/packages/php-db-import-export/tests/unit/Backend/Snowflake/Exporter/S3ExportAdapterTest.php
+++ b/packages/php-db-import-export/tests/unit/Backend/Snowflake/Exporter/S3ExportAdapterTest.php
@@ -60,7 +60,8 @@ EOT
             [],
         );
 
-        $conn->expects(self::once())->method('fetchAllAssociative')->with('select * from table(result_scan(last_query_id()));')
+        $conn->expects(self::once())->method('fetchAllAssociative')
+            ->with('select * from table(result_scan(last_query_id()));')
             ->willReturn($expectedCopyResult);
 
         $source = new Storage\Snowflake\Table('schema', 'table');
@@ -124,7 +125,8 @@ EOT
             [],
         );
 
-        $conn->expects(self::once())->method('fetchAllAssociative')->with('select * from table(result_scan(last_query_id()));')
+        $conn->expects(self::once())->method('fetchAllAssociative')
+            ->with('select * from table(result_scan(last_query_id()));')
             ->willReturn($expectedCopyResult);
 
         $source = new Storage\Snowflake\Table('schema', 'table');
@@ -188,7 +190,8 @@ EOT
             [],
         );
 
-        $conn->expects(self::once())->method('fetchAllAssociative')->with('select * from table(result_scan(last_query_id()));')
+        $conn->expects(self::once())->method('fetchAllAssociative')
+            ->with('select * from table(result_scan(last_query_id()));')
             ->willReturn($expectedCopyResult);
 
         $source = new Storage\Snowflake\SelectSource('SELECT * FROM "schema"."table"');

--- a/packages/php-db-import-export/tests/unit/Backend/Snowflake/Exporter/S3ExportAdapterTest.php
+++ b/packages/php-db-import-export/tests/unit/Backend/Snowflake/Exporter/S3ExportAdapterTest.php
@@ -33,7 +33,7 @@ class S3ExportAdapterTest extends BaseTestCase
 
         /** @var Connection|MockObject $conn */
         $conn = $this->createMock(Connection::class);
-        $conn->expects(self::once())->method('fetchAllAssociative')->with(
+        $conn->expects(self::once())->method('executeQuery')->with(
             <<<EOT
 COPY INTO 's3://bucketUrl/xxx/path'
 FROM (SELECT * FROM "schema"."table")
@@ -58,7 +58,10 @@ DETAILED_OUTPUT = TRUE
 EOT
             ,
             [],
-        )->willReturn($expectedCopyResult);
+        );
+
+        $conn->expects(self::once())->method('fetchAllAssociative')->with('select * from table(result_scan(last_query_id()));')
+            ->willReturn($expectedCopyResult);
 
         $source = new Storage\Snowflake\Table('schema', 'table');
         $options = new ExportOptions(false, ExportOptions::MANIFEST_SKIP);
@@ -94,7 +97,7 @@ EOT
 
         /** @var Connection|MockObject $conn */
         $conn = $this->createMock(Connection::class);
-        $conn->expects(self::once())->method('fetchAllAssociative')->with(
+        $conn->expects(self::once())->method('executeQuery')->with(
             <<<EOT
 COPY INTO 's3://bucketUrl/xxx/path'
 FROM (SELECT * FROM "schema"."table")
@@ -119,7 +122,10 @@ DETAILED_OUTPUT = TRUE
 EOT
             ,
             [],
-        )->willReturn($expectedCopyResult);
+        );
+
+        $conn->expects(self::once())->method('fetchAllAssociative')->with('select * from table(result_scan(last_query_id()));')
+            ->willReturn($expectedCopyResult);
 
         $source = new Storage\Snowflake\Table('schema', 'table');
         $options = new ExportOptions(true, ExportOptions::MANIFEST_SKIP);
@@ -155,7 +161,7 @@ EOT
 
         /** @var Connection|MockObject $conn */
         $conn = $this->createMock(Connection::class);
-        $conn->expects(self::once())->method('fetchAllAssociative')->with(
+        $conn->expects(self::once())->method('executeQuery')->with(
             <<<EOT
 COPY INTO 's3://bucketUrl/xxx/path'
 FROM (SELECT * FROM "schema"."table")
@@ -180,7 +186,10 @@ DETAILED_OUTPUT = TRUE
 EOT
             ,
             [],
-        )->willReturn($expectedCopyResult);
+        );
+
+        $conn->expects(self::once())->method('fetchAllAssociative')->with('select * from table(result_scan(last_query_id()));')
+            ->willReturn($expectedCopyResult);
 
         $source = new Storage\Snowflake\SelectSource('SELECT * FROM "schema"."table"');
         $options = new ExportOptions(false, ExportOptions::MANIFEST_SKIP);

--- a/packages/php-db-import-export/tests/unit/Storage/ABS/SnowflakeExportAdapterTest.php
+++ b/packages/php-db-import-export/tests/unit/Storage/ABS/SnowflakeExportAdapterTest.php
@@ -29,7 +29,7 @@ class SnowflakeExportAdapterTest extends BaseTestCase
 
         /** @var Connection|MockObject $conn */
         $conn = $this->createMock(Connection::class);
-        $conn->expects(self::once())->method('fetchAll')->with(
+        $conn->expects(self::once())->method('query')->with(
             <<<EOT
 COPY INTO 'containerUrl' 
 FROM (SELECT * FROM "schema"."table")
@@ -46,7 +46,10 @@ DETAILED_OUTPUT = TRUE
 EOT
             ,
             [],
-        )->willReturn($expectedCopyResult);
+        );
+
+        $conn->expects(self::once())->method('fetchAll')->with('select * from table(result_scan(last_query_id()));')
+            ->willReturn($expectedCopyResult);
 
         $source = new Storage\Snowflake\Table('schema', 'table');
         $options = new ExportOptions(false, ExportOptions::MANIFEST_SKIP);
@@ -79,7 +82,7 @@ EOT
 
         /** @var Connection|MockObject $conn */
         $conn = $this->createMock(Connection::class);
-        $conn->expects(self::once())->method('fetchAll')->with(
+        $conn->expects(self::once())->method('query')->with(
             <<<EOT
 COPY INTO 'containerUrl' 
 FROM (SELECT * FROM "schema"."table")
@@ -96,7 +99,10 @@ DETAILED_OUTPUT = TRUE
 EOT
             ,
             [],
-        )->willReturn($expectedCopyResult);
+        );
+
+        $conn->expects(self::once())->method('fetchAll')->with('select * from table(result_scan(last_query_id()));')
+            ->willReturn($expectedCopyResult);
 
         $source = new Storage\Snowflake\Table('schema', 'table');
         $options = new ExportOptions(true, ExportOptions::MANIFEST_SKIP);
@@ -129,7 +135,7 @@ EOT
 
         /** @var Connection|MockObject $conn */
         $conn = $this->createMock(Connection::class);
-        $conn->expects(self::once())->method('fetchAll')->with(
+        $conn->expects(self::once())->method('query')->with(
             <<<EOT
 COPY INTO 'containerUrl' 
 FROM (SELECT * FROM "schema"."table")
@@ -146,7 +152,10 @@ DETAILED_OUTPUT = TRUE
 EOT
             ,
             [],
-        )->willReturn($expectedCopyResult);
+        );
+
+        $conn->expects(self::once())->method('fetchAll')->with('select * from table(result_scan(last_query_id()));')
+            ->willReturn($expectedCopyResult);
 
         $source = new Storage\Snowflake\SelectSource('SELECT * FROM "schema"."table"');
         $options = new ExportOptions(false, ExportOptions::MANIFEST_SKIP);

--- a/packages/php-db-import-export/tests/unit/Storage/GCS/SnowflakeExportAdapterTest.php
+++ b/packages/php-db-import-export/tests/unit/Storage/GCS/SnowflakeExportAdapterTest.php
@@ -22,7 +22,7 @@ class SnowflakeExportAdapterTest extends BaseTestCase
 
         /** @var Connection|MockObject $conn */
         $conn = $this->createMock(Connection::class);
-        $conn->expects(self::once())->method('fetchAll')->with(
+        $conn->expects(self::once())->method('query')->with(
             <<<EOT
 COPY INTO 'bucket/xxx/path'
 FROM (SELECT * FROM "schema"."table")
@@ -39,7 +39,10 @@ DETAILED_OUTPUT = TRUE
 EOT
             ,
             [],
-        )->willReturn([]);
+        );
+
+        $conn->expects(self::once())->method('fetchAll')->with('select * from table(result_scan(last_query_id()));')
+            ->willReturn([]);
 
         $source = new Storage\Snowflake\Table('schema', 'table');
         $options = new ExportOptions(false, ExportOptions::MANIFEST_SKIP);
@@ -65,7 +68,7 @@ EOT
 
         /** @var Connection|MockObject $conn */
         $conn = $this->createMock(Connection::class);
-        $conn->expects(self::once())->method('fetchAll')->with(
+        $conn->expects(self::once())->method('query')->with(
             <<<EOT
 COPY INTO 'bucket/test/file'
 FROM (SELECT * FROM "schema"."table")
@@ -82,7 +85,10 @@ DETAILED_OUTPUT = TRUE
 EOT
             ,
             [],
-        )->willReturn([]);
+        );
+
+        $conn->expects(self::once())->method('fetchAll')->with('select * from table(result_scan(last_query_id()));')
+            ->willReturn([]);
 
         $source = new Storage\Snowflake\Table('schema', 'table');
         $options = new ExportOptions(true, ExportOptions::MANIFEST_SKIP);
@@ -108,7 +114,7 @@ EOT
 
         /** @var Connection|MockObject $conn */
         $conn = $this->createMock(Connection::class);
-        $conn->expects(self::once())->method('fetchAll')->with(
+        $conn->expects(self::once())->method('query')->with(
             <<<EOT
 COPY INTO 'bucket/test/file'
 FROM (SELECT * FROM "schema"."tableName")
@@ -125,7 +131,10 @@ DETAILED_OUTPUT = TRUE
 EOT
             ,
             [],
-        )->willReturn([]);
+        );
+
+        $conn->expects(self::once())->method('fetchAll')->with('select * from table(result_scan(last_query_id()));')
+            ->willReturn([]);
 
         $source = new Storage\Snowflake\SelectSource('SELECT * FROM "schema"."tableName"');
         $options = new ExportOptions(false, ExportOptions::MANIFEST_SKIP);

--- a/packages/php-db-import-export/tests/unit/Storage/S3/SnowflakeExportAdapterTest.php
+++ b/packages/php-db-import-export/tests/unit/Storage/S3/SnowflakeExportAdapterTest.php
@@ -32,7 +32,7 @@ class SnowflakeExportAdapterTest extends BaseTestCase
 
         /** @var Connection|MockObject $conn */
         $conn = $this->createMock(Connection::class);
-        $conn->expects(self::once())->method('fetchAll')->with(
+        $conn->expects(self::once())->method('query')->with(
             <<<EOT
 COPY INTO 's3://bucketUrl/xxx/path'
 FROM (SELECT * FROM "schema"."table")
@@ -56,7 +56,10 @@ DETAILED_OUTPUT = TRUE
 EOT
             ,
             [],
-        )->willReturn($expectedCopyResult);
+        );
+
+        $conn->expects(self::once())->method('fetchAll')->with('select * from table(result_scan(last_query_id()));')
+            ->willReturn($expectedCopyResult);
 
         $source = new Storage\Snowflake\Table('schema', 'table');
         $options = new ExportOptions(false, ExportOptions::MANIFEST_SKIP);
@@ -92,7 +95,7 @@ EOT
 
         /** @var Connection|MockObject $conn */
         $conn = $this->createMock(Connection::class);
-        $conn->expects(self::once())->method('fetchAll')->with(
+        $conn->expects(self::once())->method('query')->with(
             <<<EOT
 COPY INTO 's3://bucketUrl/xxx/path'
 FROM (SELECT * FROM "schema"."table")
@@ -116,7 +119,10 @@ DETAILED_OUTPUT = TRUE
 EOT
             ,
             [],
-        )->willReturn($expectedCopyResult);
+        );
+
+        $conn->expects(self::once())->method('fetchAll')->with('select * from table(result_scan(last_query_id()));')
+            ->willReturn($expectedCopyResult);
 
         $source = new Storage\Snowflake\Table('schema', 'table');
         $options = new ExportOptions(true, ExportOptions::MANIFEST_SKIP);
@@ -152,7 +158,7 @@ EOT
 
         /** @var Connection|MockObject $conn */
         $conn = $this->createMock(Connection::class);
-        $conn->expects(self::once())->method('fetchAll')->with(
+        $conn->expects(self::once())->method('query')->with(
             <<<EOT
 COPY INTO 's3://bucketUrl/xxx/path'
 FROM (SELECT * FROM "schema"."table")
@@ -176,7 +182,10 @@ DETAILED_OUTPUT = TRUE
 EOT
             ,
             [],
-        )->willReturn($expectedCopyResult);
+        );
+
+        $conn->expects(self::once())->method('fetchAll')->with('select * from table(result_scan(last_query_id()));')
+            ->willReturn($expectedCopyResult);
 
         $source = new Storage\Snowflake\SelectSource('SELECT * FROM "schema"."table"');
         $options = new ExportOptions(false, ExportOptions::MANIFEST_SKIP);


### PR DESCRIPTION
Jira: PAT-261 https://keboolaglobal.slack.com/archives/C08L30T94NM 
Connection PR: XXX
SAPI PR: XXX

---

COPY INTO sometimes won't return all result files. By calling result_scan on last_query_id we are fixing this problem.
It was tested that this works, it's not easy to replicate.