### PR TITLE
Update Dockerfile RUN git config --system --add safe.directory /monorepo

### DIFF
--- a/bin/Dockerfile
+++ b/bin/Dockerfile
@@ -13,3 +13,5 @@ RUN echo "deb http://deb.debian.org/debian bookworm-backports main contrib non-f
     && mkdir -p ~/.ssh || true \
     && chmod 700 ~/.ssh/ \
     && ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
+
+RUN git config --system --add safe.directory /monorepo


### PR DESCRIPTION
Jira: CT-XXX
Connection PR: XXX
SAPI PR: XXX

---
```
>> Cloning source repo '.'
Cloning into bare repository '/tmp/tmp.oZFPEcQvsT'...
fatal: detected dubious ownership in repository at '/monorepo/./.git'
To add an exception for this directory, call:

	git config --global --add safe.directory /monorepo/./.git
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```
Stale [pada](https://github.com/keboola/storage-backend/actions/runs/16614384925/job/47004096160) monorepo split s cursorom sme doplnili toto  `RUN git config --system --add safe.directory /monorepo`