### PR TITLE
fix  safe.directory "${ABSOLUTE_SOURCE_PATH}"/.git

### DIFF
--- a/bin/split-repo.sh
+++ b/bin/split-repo.sh
@@ -24,7 +24,7 @@ LAST_TAG_IN_SINGLEREPO="${5}"
 ABSOLUTE_SOURCE_PATH=$(realpath "${SOURCE_REPO_PATH}")
 
 # Configure git to trust our repository paths
-git config --system --add safe.directory "${ABSOLUTE_SOURCE_PATH}"
+git config --system --add safe.directory "${ABSOLUTE_SOURCE_PATH}"/.git
 
 # We require the source to be a local path because we use --mirror flag. The --mirror flag is needed on the other hand
 # to copy all refs when doing a local clone.


### PR DESCRIPTION
Jira: CT-XXX
Connection PR: XXX
SAPI PR: XXX

---
Bolo to este o tej ceste tu to preslo https://github.com/keboola/storage-backend/actions/runs/16625370535
ked som ju tam nemal tak to spadlo https://github.com/keboola/storage-backend/actions/runs/16625558442/job/47040885666

cely thread k tomu https://keboolaglobal.slack.com/archives/C0553EM2RGX/p1753885709781759?thread_ts=1753873603.380559&cid=C0553EM2RGX