### PR TITLE
php-datatypes: New BigQuery alias FLOAT, BOOLEAN

### DIFF
--- a/packages/php-datatypes/src/Definition/Bigquery.php
+++ b/packages/php-datatypes/src/Definition/Bigquery.php
@@ -37,7 +37,9 @@ class Bigquery extends Common
 
     public const TYPE_ARRAY = 'ARRAY';
 
+    // BOOL
     public const TYPE_BOOL = 'BOOL'; // NULL,TRUE,FALSE
+    public const TYPE_BOOLEAN = 'BOOLEAN'; // REST API alias
 
     public const TYPE_BYTES = 'BYTES'; // BYTES(L) L is a positive INT64
 
@@ -71,7 +73,9 @@ class Bigquery extends Common
     // alias for BIGNUMERIC
     public const TYPE_BIGDECIMAL = 'BIGDECIMAL';
 
+    // FLOAT64
     public const TYPE_FLOAT64 = 'FLOAT64';
+    public const TYPE_FLOAT = 'FLOAT'; // REST API alias
 
     public const TYPE_STRING = 'STRING'; // STRING(L) L is a positive INT64 value
 
@@ -114,6 +118,8 @@ class Bigquery extends Common
         self::TYPE_BYTEINT,
         self::TYPE_DECIMAL,
         self::TYPE_BIGDECIMAL,
+        self::TYPE_FLOAT,
+        self::TYPE_BOOLEAN,
     ];
 
     /* @see https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#TableFieldSchema */
@@ -224,9 +230,11 @@ class Bigquery extends Common
                 $basetype = BaseType::NUMERIC;
                 break;
             case self::TYPE_FLOAT64:
+            case self::TYPE_FLOAT:
                 $basetype = BaseType::FLOAT;
                 break;
             case self::TYPE_BOOL:
+            case self::TYPE_BOOLEAN:
                 $basetype = BaseType::BOOLEAN;
                 break;
             case self::TYPE_DATE:
@@ -295,6 +303,8 @@ class Bigquery extends Common
             self::TYPE_BYTEINT => self::TYPE_INTEGER,
             self::TYPE_DECIMAL => self::TYPE_NUMERIC,
             self::TYPE_BIGDECIMAL => self::TYPE_BIGNUMERIC,
+            self::TYPE_FLOAT => self::TYPE_FLOAT64,
+            self::TYPE_BOOLEAN => self::TYPE_BOOL,
             default => $this->type
         };
     }

--- a/packages/php-datatypes/tests/BigqueryDatatypeTest.php
+++ b/packages/php-datatypes/tests/BigqueryDatatypeTest.php
@@ -53,6 +53,7 @@ class BigqueryDatatypeTest extends BaseDatatypeTestCase
             ['bigdecimal', '78'],
 
             ['bool', 'anyLength'],
+            ['boolean', 'anyLength'],
             ['bytes', 'anyLength'],
             ['date', 'anyLength'],
             ['datetime', 'anyLength'],
@@ -69,6 +70,7 @@ class BigqueryDatatypeTest extends BaseDatatypeTestCase
             ['tinyint', 'anyLength'],
             ['byteint', 'anyLength'],
             ['float64', 'anyLength'],
+            ['float', 'anyLength'],
         ];
     }
 
@@ -110,9 +112,11 @@ class BigqueryDatatypeTest extends BaseDatatypeTestCase
                     $this->assertEquals(BaseType::NUMERIC, $basetype);
                     break;
                 case 'FLOAT64':
+                case 'FLOAT':
                     $this->assertEquals(BaseType::FLOAT, $basetype);
                     break;
                 case 'BOOL':
+                case 'BOOLEAN':
                     $this->assertEquals(BaseType::BOOLEAN, $basetype);
                     break;
                 case 'DATE':
@@ -333,6 +337,7 @@ class BigqueryDatatypeTest extends BaseDatatypeTestCase
             ['bignumeric', '76,38'],
 
             ['bool', null],
+            ['boolean', null],
             ['date', null],
             ['datetime', null],
             ['time', null],
@@ -348,6 +353,7 @@ class BigqueryDatatypeTest extends BaseDatatypeTestCase
             ['tinyint', null],
             ['byteint', null],
             ['float64', null],
+            ['float', null],
         ];
     }
 
@@ -498,6 +504,8 @@ class BigqueryDatatypeTest extends BaseDatatypeTestCase
                 Bigquery::TYPE_BYTEINT => Bigquery::TYPE_INTEGER,
                 Bigquery::TYPE_DECIMAL => Bigquery::TYPE_NUMERIC,
                 Bigquery::TYPE_BIGDECIMAL => Bigquery::TYPE_BIGNUMERIC,
+                Bigquery::TYPE_FLOAT => Bigquery::TYPE_FLOAT64,
+                Bigquery::TYPE_BOOLEAN => Bigquery::TYPE_BOOL,
                 default => $type,
             };
 


### PR DESCRIPTION
Jira: −
Connection PR: −
SAPI PR: keboola/storage-api-php-client#1560

**Need there:** [php-storage-driver-bigquery#174](https://github.com/keboola/php-storage-driver-bigquery/pull/174/files#diff-2fea2b7eabcf453f075d41dd2c332e481a4fb7157007866e31663a739c5786a8R147)
Indirect dependeny in `Bigquery($type))->getBasetype()` where new aliases could be come from API to `$type`.


---

- New alias FLOAT for FLOAT64, BOOLEAN for BOOL.
- It's not in documentation (https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#numeric_types) but works in SQL.
- It's in REST API documentation (https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#TableFieldSchema) and based on my observations REST API returns only FLOAT or BOOLEAN.