### PR TITLE
DMD-433 Delete mode from numeric stats profiling metric

### DIFF
--- a/packages/php-storage-driver-snowflake/src/Profile/Column/NumericStatisticsColumnMetric.php
+++ b/packages/php-storage-driver-snowflake/src/Profile/Column/NumericStatisticsColumnMetric.php
@@ -17,13 +17,12 @@ final class NumericStatisticsColumnMetric implements ColumnMetricInterface
 
     public function description(): string
     {
-        return 'Basic statistics for numeric column (average, mode, median minimum and maximum).';
+        return 'Basic statistics for numeric column (average, median minimum and maximum).';
     }
 
     /**
      * @return array{
      *     avg: float|null,
-     *     mode: float|null,
      *     median: float|null,
      *     min: float|null,
      *     max: float|null,
@@ -41,13 +40,11 @@ final class NumericStatisticsColumnMetric implements ColumnMetricInterface
             <<<'SQL'
                 SELECT
                     AVG(%s) AS stats_avg,
-                    MODE(%s) AS stats_mode,
                     MEDIAN(%s) AS stats_median,
                     MIN(%s) AS stats_min,
                     MAX(%s) AS stats_max
                 FROM %s.%s
                 SQL,
-            $columnQuoted,
             $columnQuoted,
             $columnQuoted,
             $columnQuoted,
@@ -59,7 +56,6 @@ final class NumericStatisticsColumnMetric implements ColumnMetricInterface
         /**
          * @var array{
          *     STATS_AVG: string|null,
-         *     STATS_MODE: string|null,
          *     STATS_MEDIAN: string|null,
          *     STATS_MIN: string|null,
          *     STATS_MAX: string|null,
@@ -69,7 +65,6 @@ final class NumericStatisticsColumnMetric implements ColumnMetricInterface
 
         return [
             'avg' => $result['STATS_AVG'] !== null ? (float) $result['STATS_AVG'] : null,
-            'mode' => $result['STATS_MODE'] !== null ? (float) $result['STATS_MODE'] : null,
             'median' => $result['STATS_MEDIAN'] !== null ? (float) $result['STATS_MEDIAN'] : null,
             'min' => $result['STATS_MIN'] !== null ? (float) $result['STATS_MIN'] : null,
             'max' => $result['STATS_MAX'] !== null ? (float) $result['STATS_MAX'] : null,

--- a/packages/php-storage-driver-snowflake/tests/Functional/Handler/ProfileTableHandlerTest.php
+++ b/packages/php-storage-driver-snowflake/tests/Functional/Handler/ProfileTableHandlerTest.php
@@ -48,12 +48,12 @@ final class ProfileTableHandlerTest extends BaseCase
 
         /** @var array<string, string> $expectedColumnProfiles */
         $expectedColumnProfiles = [
-            'id' => '{"distinctCount":8,"duplicateCount":0,"nullCount":0,"numericStatistics":{"avg":4.5,"mode":4,"median":4.5,"min":1,"max":8}}', // phpcs:ignore
+            'id' => '{"distinctCount":8,"duplicateCount":0,"nullCount":0,"numericStatistics":{"avg":4.5,"median":4.5,"min":1,"max":8}}', // phpcs:ignore
             'col_varchar' => '{"distinctCount":7,"duplicateCount":1,"nullCount":0,"length":{"avg":14.5,"min":9,"max":20}}', // phpcs:ignore
             'col_bool' => '{"distinctCount":2,"duplicateCount":5,"nullCount":1}',
-            'col_number' => '{"distinctCount":5,"duplicateCount":2,"nullCount":1,"numericStatistics":{"avg":75.714286,"mode":120,"median":60,"min":0,"max":200}}', // phpcs:ignore
-            'col_decimal' => '{"distinctCount":6,"duplicateCount":1,"nullCount":1,"numericStatistics":{"avg":108.857143,"mode":30,"median":30,"min":16,"max":499}}', // phpcs:ignore
-            'col_float' => '{"distinctCount":5,"duplicateCount":2,"nullCount":1,"numericStatistics":{"avg":4.11428571428571,"mode":4.5,"median":4.5,"min":2.4,"max":4.9}}', // phpcs:ignore
+            'col_number' => '{"distinctCount":5,"duplicateCount":2,"nullCount":1,"numericStatistics":{"avg":75.714286,"median":60,"min":0,"max":200}}', // phpcs:ignore
+            'col_decimal' => '{"distinctCount":6,"duplicateCount":1,"nullCount":1,"numericStatistics":{"avg":108.857143,"median":30,"min":16,"max":499}}', // phpcs:ignore
+            'col_float' => '{"distinctCount":5,"duplicateCount":2,"nullCount":1,"numericStatistics":{"avg":4.11428571428571,"median":4.5,"min":2.4,"max":4.9}}', // phpcs:ignore
             'col_date' => '{"distinctCount":6,"duplicateCount":1,"nullCount":1}',
         ];
 

--- a/packages/php-storage-driver-snowflake/tests/Functional/Profile/Column/DecimalColumnMetricTest.php
+++ b/packages/php-storage-driver-snowflake/tests/Functional/Profile/Column/DecimalColumnMetricTest.php
@@ -117,7 +117,6 @@ final class DecimalColumnMetricTest extends BaseCase
             self::COLUMN_DECIMAL_NOT_NULLABLE,
             [
                 'avg' => 1111111117.7657223,
-                'mode' => 10.5,
                 'median' => 10.5,
                 'min' => -5.25,
                 'max' => 9999999999.9999,
@@ -136,7 +135,6 @@ final class DecimalColumnMetricTest extends BaseCase
             self::COLUMN_DECIMAL_NULLABLE,
             [
                 'avg' => 1666666669.4583333,
-                'mode' => 10.5,
                 'median' => 5.75,
                 'min' => -5.25,
                 'max' => 10000000000.0,

--- a/packages/php-storage-driver-snowflake/tests/Functional/Profile/Column/FloatColumnMetricTest.php
+++ b/packages/php-storage-driver-snowflake/tests/Functional/Profile/Column/FloatColumnMetricTest.php
@@ -117,7 +117,6 @@ final class FloatColumnMetricTest extends BaseCase
             self::COLUMN_FLOAT_NOT_NULLABLE,
             [
                 'avg' => 13830.3376666667,
-                'mode' => 4.56,
                 'median' => 4.56,
                 'min' => -3.21,
                 'max' => 123456.789,
@@ -136,7 +135,6 @@ final class FloatColumnMetricTest extends BaseCase
             self::COLUMN_FLOAT_NULLABLE,
             [
                 'avg' => 20577.3215,
-                'mode' => 1.23,
                 'median' => 1.23,
                 'min' => -3.21,
                 'max' => 123456.789,

--- a/packages/php-storage-driver-snowflake/tests/Functional/Profile/Column/NumberColumnMetricTest.php
+++ b/packages/php-storage-driver-snowflake/tests/Functional/Profile/Column/NumberColumnMetricTest.php
@@ -118,7 +118,6 @@ final class NumberColumnMetricTest extends BaseCase
             self::COLUMN_NUMBER_NOT_NULLABLE,
             [
                 'avg' => 90919.272727,
-                'mode' => 5.0,
                 'median' => 3.0,
                 'min' => -10.0,
                 'max' => 999999.0,
@@ -137,7 +136,6 @@ final class NumberColumnMetricTest extends BaseCase
             self::COLUMN_NUMBER_NULLABLE,
             [
                 'avg' => 13.375000,
-                'mode' => 5.0,
                 'median' => 3.0,
                 'min' => -10.0,
                 'max' => 100.0,
@@ -156,7 +154,6 @@ final class NumberColumnMetricTest extends BaseCase
             self::COLUMN_ONLY_NULL,
             [
                 'avg' => null,
-                'mode' => null,
                 'median' => null,
                 'min' => null,
                 'max' => null,
@@ -189,7 +186,7 @@ final class NumberColumnMetricTest extends BaseCase
                         self::COLUMN_VARCHAR_NULLABLE,
                         new Snowflake(Snowflake::TYPE_VARCHAR, ['nullable' => true]),
                     ),
-                    // AVG, MODE, MEDIAN, MIN, MAX returns NULL if all records are NULL.
+                    // AVG, MEDIAN, MIN, MAX returns NULL if all records are NULL.
                     new SnowflakeColumn(
                         self::COLUMN_ONLY_NULL,
                         new Snowflake(Snowflake::TYPE_NUMBER, ['nullable' => true]),


### PR DESCRIPTION
**Jira**: DMD-433
**KBC**: [keboola/connection#6242](https://github.com/keboola/connection/pull/6242)
**SAPI**: [keboola/storage-api-php-client#1577](https://github.com/keboola/storage-api-php-client/pull/1577)
**BigQuery driver**: [keboola/php-storage-driver-bigquery#180](https://github.com/keboola/php-storage-driver-bigquery/pull/180)



---

- [ ] Create tag
- [ ] Create release in read-only repo

---

**Release Notes**
- Remove mode value from table profiling numeric statistics.

**Impact analysis**
- None

**Change type**
- Fix

**Justification**
- Mode doesn't return all values for multimodal sets. Now we have no time for stable solution. So we will remove mode from numeric statistics metric.

