### PR TITLE
feat: upgrade google/protobuf to v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "ext-pdo": "*",
         "google/cloud-bigquery": "^1.23",
         "google/cloud-storage": "^1.27",
-        "google/protobuf": "^3.21",
+        "google/protobuf": "^4.33.6",
         "keboola/common-exceptions": "^1",
         "keboola/csv-options": "^1",
         "keboola/php-csv-db-import": "^6",

--- a/packages/php-storage-driver-common/composer.json
+++ b/packages/php-storage-driver-common/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": "^8.3",
         "ext-json": "*",
-        "google/protobuf": "^3.21",
+        "google/protobuf": "^4.33.6",
         "keboola/php-file-storage-utils": "^0.2.2",
         "keboola/common-exceptions": "^1",
         "aws/aws-sdk-php": "^3"


### PR DESCRIPTION
Jira: CT-XXX
Connection PR: XXX
SAPI PR: XXX

---

- [ ] Create tag
- [ ] Create release in read-only repo

---

**Release Notes**
- Upgrade google/protobuf dependency from v3 to v4

**Impact analysis**
- Protobuf v4 is a major version bump - generated protobuf classes may have breaking API changes
- All services using protobuf-based communication (gRPC drivers) need to be verified

**Change type**
- dependency upgrade

**Justification**
- google/protobuf v3 is reaching end of support, upgrading to v4 ensures continued compatibility and access to latest features and security fixes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)