### PR TITLE
DMD-1050 - feat: add keboola-prefixed query tag keys and queryTags support in SnowflakeConnection

### DIFF
--- a/packages/php-table-backend-utils/src/Connection/Bigquery/QueryTagKey.php
+++ b/packages/php-table-backend-utils/src/Connection/Bigquery/QueryTagKey.php
@@ -10,6 +10,9 @@ enum QueryTagKey: string
 {
     case BRANCH_ID = 'branch_id';
     case RUN_ID = 'run_id';
+    case KEBOOLA_RUN_ID = 'keboola_run_id';
+    case KEBOOLA_BRANCH_ID = 'keboola_branch_id';
+    case KEBOOLA_SERVICE = 'keboola_service';
 
     /**
      * Validates if the given string is a valid tag key

--- a/packages/php-table-backend-utils/src/Connection/Snowflake/SnowflakeConnection.php
+++ b/packages/php-table-backend-utils/src/Connection/Snowflake/SnowflakeConnection.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Driver\Connection;
 use Doctrine\DBAL\Driver\Result;
 use Doctrine\DBAL\ParameterType;
 use Exception;
+use JsonException;
 use Keboola\TableBackendUtils\Connection\Exception\DriverException;
 use Keboola\TableBackendUtils\Escaping\Snowflake\SnowflakeQuote;
 use Throwable;
@@ -41,14 +42,29 @@ class SnowflakeConnection implements Connection
             throw DriverException::newConnectionFailure($e->getMessage(), (int) $e->getCode(), $e->getPrevious());
         }
         $queryTag = [];
-        if (isset($options['queryTags']) && is_array($options['queryTags'])) {
+        if (isset($options['queryTags'])) {
+            if (!is_array($options['queryTags'])) {
+                throw DriverException::newConnectionFailure(
+                    sprintf('Invalid "queryTags" option: expected array, got %s.', gettype($options['queryTags'])),
+                    0,
+                    null,
+                );
+            }
             $queryTag = $options['queryTags'];
         }
         if (isset($options['runId'])) {
             $queryTag['runId'] = $options['runId'];
         }
         if ($queryTag !== []) {
-            $queryTagJson = json_encode($queryTag, JSON_THROW_ON_ERROR);
+            try {
+                $queryTagJson = json_encode($queryTag, JSON_THROW_ON_ERROR);
+            } catch (JsonException $e) {
+                throw DriverException::newConnectionFailure(
+                    sprintf('Failed to encode queryTags to JSON: %s', $e->getMessage()),
+                    0,
+                    $e,
+                );
+            }
             $this->query('ALTER SESSION SET QUERY_TAG=' . SnowflakeQuote::quote($queryTagJson) . ';');
         }
     }

--- a/packages/php-table-backend-utils/src/Connection/Snowflake/SnowflakeConnection.php
+++ b/packages/php-table-backend-utils/src/Connection/Snowflake/SnowflakeConnection.php
@@ -40,10 +40,14 @@ class SnowflakeConnection implements Connection
         } catch (Throwable $e) {
             throw DriverException::newConnectionFailure($e->getMessage(), (int) $e->getCode(), $e->getPrevious());
         }
+        $queryTag = [];
         if (isset($options['runId'])) {
-            $queryTag = [
-                'runId' => $options['runId'],
-            ];
+            $queryTag['runId'] = $options['runId'];
+        }
+        if (isset($options['queryTags']) && is_array($options['queryTags'])) {
+            $queryTag = array_merge($queryTag, $options['queryTags']);
+        }
+        if ($queryTag !== []) {
             $this->query("ALTER SESSION SET QUERY_TAG='" . json_encode($queryTag, JSON_THROW_ON_ERROR) . "';");
         }
     }

--- a/packages/php-table-backend-utils/src/Connection/Snowflake/SnowflakeConnection.php
+++ b/packages/php-table-backend-utils/src/Connection/Snowflake/SnowflakeConnection.php
@@ -49,7 +49,7 @@ class SnowflakeConnection implements Connection
         }
         if ($queryTag !== []) {
             $queryTagJson = json_encode($queryTag, JSON_THROW_ON_ERROR);
-            $this->query("ALTER SESSION SET QUERY_TAG=" . SnowflakeQuote::quote($queryTagJson) . ";");
+            $this->query('ALTER SESSION SET QUERY_TAG=' . SnowflakeQuote::quote($queryTagJson) . ';');
         }
     }
 

--- a/packages/php-table-backend-utils/src/Connection/Snowflake/SnowflakeConnection.php
+++ b/packages/php-table-backend-utils/src/Connection/Snowflake/SnowflakeConnection.php
@@ -41,14 +41,15 @@ class SnowflakeConnection implements Connection
             throw DriverException::newConnectionFailure($e->getMessage(), (int) $e->getCode(), $e->getPrevious());
         }
         $queryTag = [];
+        if (isset($options['queryTags']) && is_array($options['queryTags'])) {
+            $queryTag = $options['queryTags'];
+        }
         if (isset($options['runId'])) {
             $queryTag['runId'] = $options['runId'];
         }
-        if (isset($options['queryTags']) && is_array($options['queryTags'])) {
-            $queryTag = array_merge($queryTag, $options['queryTags']);
-        }
         if ($queryTag !== []) {
-            $this->query("ALTER SESSION SET QUERY_TAG='" . json_encode($queryTag, JSON_THROW_ON_ERROR) . "';");
+            $queryTagJson = json_encode($queryTag, JSON_THROW_ON_ERROR);
+            $this->query("ALTER SESSION SET QUERY_TAG=" . SnowflakeQuote::quote($queryTagJson) . ";");
         }
     }
 

--- a/packages/php-table-backend-utils/src/Connection/Snowflake/SnowflakeDSNGenerator.php
+++ b/packages/php-table-backend-utils/src/Connection/Snowflake/SnowflakeDSNGenerator.php
@@ -43,7 +43,8 @@ class SnowflakeDSNGenerator
      *     'networkTimeout'?:int,
      *     'queryTimeout'?: int,
      *     'clientSessionKeepAlive'?: bool,
-     *     'maxBackoffAttempts'?:int
+     *     'maxBackoffAttempts'?:int,
+     *     'queryTags'?: array<string, string>
      * } $options
      */
     public static function generateDSN(array $options): string

--- a/packages/php-table-backend-utils/src/Connection/Snowflake/SnowflakeDSNGenerator.php
+++ b/packages/php-table-backend-utils/src/Connection/Snowflake/SnowflakeDSNGenerator.php
@@ -68,6 +68,7 @@ class SnowflakeDSNGenerator
             'schema',
             'warehouse',
             'runId',
+            'queryTags',
             'clientSessionKeepAlive',
             'driverClass',
             'driverOptions',

--- a/packages/php-table-backend-utils/tests/Functional/Snowflake/ConnectionTest.php
+++ b/packages/php-table-backend-utils/tests/Functional/Snowflake/ConnectionTest.php
@@ -350,6 +350,75 @@ SQL,);
         $this->assertEquals('{"runId":"runIdValue"}', $queries[0]['QUERY_TAG']);
     }
 
+    public function testQueryTaggingWithQueryTags(): void
+    {
+        $connection = SnowflakeConnectionFactory::getConnection(
+            (string) getenv('SNOWFLAKE_HOST'), // @phpstan-ignore cast.string
+            (string) getenv('SNOWFLAKE_USER'), // @phpstan-ignore cast.string
+            (string) getenv('SNOWFLAKE_PASSWORD'), // @phpstan-ignore cast.string
+            [
+                'port' => (string) getenv('SNOWFLAKE_PORT'), // @phpstan-ignore cast.string
+                'warehouse' => (string) getenv('SNOWFLAKE_WAREHOUSE'), // @phpstan-ignore cast.string
+                'database' => (string) getenv('SNOWFLAKE_DATABASE'), // @phpstan-ignore cast.string
+                'runId' => 'runIdValue',
+                'queryTags' => [
+                    'keboola_branch_id' => 'branch-123',
+                    'keboola_service' => 'sapi',
+                ],
+            ],
+        );
+
+        $connection->executeQuery('SELECT current_date;');
+        $queries = $connection->fetchAllAssociative(<<<SQL
+    SELECT
+        QUERY_TEXT, QUERY_TAG
+    FROM
+        TABLE(INFORMATION_SCHEMA.QUERY_HISTORY_BY_SESSION())
+    WHERE QUERY_TEXT = 'SELECT current_date;'
+    ORDER BY START_TIME DESC
+    LIMIT 1
+SQL,);
+
+        $this->assertEquals(
+            '{"keboola_branch_id":"branch-123","keboola_service":"sapi","runId":"runIdValue"}',
+            $queries[0]['QUERY_TAG'],
+        );
+    }
+
+    public function testQueryTaggingRunIdTakesPrecedence(): void
+    {
+        $connection = SnowflakeConnectionFactory::getConnection(
+            (string) getenv('SNOWFLAKE_HOST'), // @phpstan-ignore cast.string
+            (string) getenv('SNOWFLAKE_USER'), // @phpstan-ignore cast.string
+            (string) getenv('SNOWFLAKE_PASSWORD'), // @phpstan-ignore cast.string
+            [
+                'port' => (string) getenv('SNOWFLAKE_PORT'), // @phpstan-ignore cast.string
+                'warehouse' => (string) getenv('SNOWFLAKE_WAREHOUSE'), // @phpstan-ignore cast.string
+                'database' => (string) getenv('SNOWFLAKE_DATABASE'), // @phpstan-ignore cast.string
+                'runId' => 'correctRunId',
+                'queryTags' => [
+                    'runId' => 'overriddenRunId',
+                ],
+            ],
+        );
+
+        $connection->executeQuery('SELECT current_date;');
+        $queries = $connection->fetchAllAssociative(<<<SQL
+    SELECT
+        QUERY_TEXT, QUERY_TAG
+    FROM
+        TABLE(INFORMATION_SCHEMA.QUERY_HISTORY_BY_SESSION())
+    WHERE QUERY_TEXT = 'SELECT current_date;'
+    ORDER BY START_TIME DESC
+    LIMIT 1
+SQL,);
+
+        $this->assertEquals(
+            '{"runId":"correctRunId"}',
+            $queries[0]['QUERY_TAG'],
+        );
+    }
+
     #[DataProvider('connectionProvider')]
     public function testQueryTimeoutLimit(Connection $connection): void
     {

--- a/packages/php-table-backend-utils/tests/Unit/Connection/Bigquery/QueryTagsTest.php
+++ b/packages/php-table-backend-utils/tests/Unit/Connection/Bigquery/QueryTagsTest.php
@@ -47,7 +47,7 @@ class QueryTagsTest extends TestCase
     public function testInvalidQueryTagsInConstructor(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid query tag key "invalid_key". Valid keys are: branch_id');
+        $this->expectExceptionMessage('Invalid query tag key "invalid_key". Valid keys are: branch_id, run_id, keboola_run_id, keboola_branch_id, keboola_service');
 
         new QueryTags([
             'invalid_key' => 'some-value',
@@ -57,7 +57,7 @@ class QueryTagsTest extends TestCase
     public function testInvalidQueryTagsAddition(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid query tag key "invalid_key". Valid keys are: branch_id');
+        $this->expectExceptionMessage('Invalid query tag key "invalid_key". Valid keys are: branch_id, run_id, keboola_run_id, keboola_branch_id, keboola_service');
 
         $queryTags = new QueryTags();
         $queryTags->addTag('invalid_key', 'some-value');
@@ -74,6 +74,35 @@ class QueryTagsTest extends TestCase
             ['branch_id' => 'test-branch-2'],
             $queryTags->toArray(),
         );
+    }
+
+    public function testKeboolaPrefixedTags(): void
+    {
+        $queryTags = new QueryTags([
+            QueryTagKey::KEBOOLA_RUN_ID->value => 'test-run-123',
+            QueryTagKey::KEBOOLA_BRANCH_ID->value => 'test-branch-456',
+            QueryTagKey::KEBOOLA_SERVICE->value => 'sapi',
+        ]);
+
+        $this->assertFalse($queryTags->isEmpty());
+        $this->assertCount(3, $queryTags->toArray());
+        $this->assertSame('test-run-123', $queryTags->toArray()['keboola_run_id']);
+        $this->assertSame('test-branch-456', $queryTags->toArray()['keboola_branch_id']);
+        $this->assertSame('sapi', $queryTags->toArray()['keboola_service']);
+    }
+
+    public function testAllTagsCombined(): void
+    {
+        $queryTags = new QueryTags([
+            QueryTagKey::BRANCH_ID->value => 'branch-1',
+            QueryTagKey::RUN_ID->value => 'run-1',
+            QueryTagKey::KEBOOLA_RUN_ID->value => 'run-1',
+            QueryTagKey::KEBOOLA_BRANCH_ID->value => 'branch-1',
+            QueryTagKey::KEBOOLA_SERVICE->value => 'sapi',
+        ]);
+
+        $this->assertFalse($queryTags->isEmpty());
+        $this->assertCount(5, $queryTags->toArray());
     }
 
     #[DataProvider('validQueryTagsValuesProvider')]

--- a/packages/php-table-backend-utils/tests/Unit/Connection/Bigquery/QueryTagsTest.php
+++ b/packages/php-table-backend-utils/tests/Unit/Connection/Bigquery/QueryTagsTest.php
@@ -47,7 +47,10 @@ class QueryTagsTest extends TestCase
     public function testInvalidQueryTagsInConstructor(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid query tag key "invalid_key". Valid keys are: branch_id, run_id, keboola_run_id, keboola_branch_id, keboola_service');
+        $this->expectExceptionMessage(
+            'Invalid query tag key "invalid_key".'
+            . ' Valid keys are: branch_id, run_id, keboola_run_id, keboola_branch_id, keboola_service',
+        );
 
         new QueryTags([
             'invalid_key' => 'some-value',
@@ -57,7 +60,10 @@ class QueryTagsTest extends TestCase
     public function testInvalidQueryTagsAddition(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid query tag key "invalid_key". Valid keys are: branch_id, run_id, keboola_run_id, keboola_branch_id, keboola_service');
+        $this->expectExceptionMessage(
+            'Invalid query tag key "invalid_key".'
+            . ' Valid keys are: branch_id, run_id, keboola_run_id, keboola_branch_id, keboola_service',
+        );
 
         $queryTags = new QueryTags();
         $queryTags->addTag('invalid_key', 'some-value');

--- a/packages/php-table-backend-utils/tests/Unit/Connection/Snowflake/SnowflakeDSNGeneratorTest.php
+++ b/packages/php-table-backend-utils/tests/Unit/Connection/Snowflake/SnowflakeDSNGeneratorTest.php
@@ -32,6 +32,7 @@ class SnowflakeDSNGeneratorTest extends TestCase
             'schema' => 'snowflake_schema',
             'warehouse' => 'snowflake_warehouse',
             'runId' => 'snowflake_runId',
+            'queryTags' => [],
             'clientSessionKeepAlive' => true,
             'driverClass' => 'DBAL\DRIVER',
             'driverOptions' => [],


### PR DESCRIPTION
Jira: DMD-1050
Connection PR:  https://github.com/keboola/connection/pull/6959
---
Je to aj vramci tohoto https://linear.app/keboola/issue/DMD-611/prefixovat-query-tagy-a-zjednotit-ich-pridat-branch-id-na-snflk 

Pridam rovno nove s prefixom `keboola_` vykomunikujem ze to budeme menit a pak tie stare tagy zmazem.

- [ ] Create tag
- [ ] Create release in read-only repo

---

**Release Notes**
- Add `keboola_run_id`, `keboola_branch_id`, `keboola_service` query tag keys for BigQuery
- Support arbitrary `queryTags` option in SnowflakeConnection for additional session tags

**Impact analysis**
- Extends existing query tagging with new keboola-prefixed keys, fully backward compatible
- No risk to existing functionality — new keys are additive, existing `runId` / `branch_id` behavior unchanged

**Change type**
- New feature

**Justification**
- Backend services need to propagate Keboola-specific metadata (run ID, branch ID, service name) as query tags to both Snowflake and BigQuery for better observability and query attribution. The existing tag keys (`run_id`, `branch_id`) are generic and don't carry the `keboola_` prefix required by the new tagging convention. Additionally, SnowflakeConnection only supported a hardcoded `runId` tag — the new `queryTags` option allows callers to pass arbitrary key-value pairs, enabling flexible tag propagation without further code changes.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)